### PR TITLE
Keep Accessibility permission stable across builds

### DIFF
--- a/scripts/build_app.sh
+++ b/scripts/build_app.sh
@@ -26,6 +26,13 @@ sed -e "s/__VERSION__/$VERSION/" -e "s/__BUILD__/$BUILD/" \
 
 printf 'APPL????' > "$APP/Contents/PkgInfo"
 
+# Explicitly sign the assembled bundle with a stable designated requirement.
+# Without this, each release build only carries Swift's per-binary linker
+# signature (a changing CDHash), which makes macOS ask for Accessibility again.
+echo "==> Signing $APP"
+/usr/bin/codesign --force --sign - --identifier com.greycorelabs.pesty \
+  -r='designated => identifier "com.greycorelabs.pesty"' "$APP"
+
 echo "==> Built $APP"
 /usr/bin/file "$APP/Contents/MacOS/Pesty"
 echo "    version $VERSION ($BUILD)"


### PR DESCRIPTION
## Summary

- Explicitly sign the assembled app bundle with Pesty's stable bundle identifier.
- Add a stable designated requirement so macOS does not treat each rebuilt ad-hoc app as a new Accessibility client.

## Validation

- `swift build`
- `VERSION=1.0.0 BUILD=1 ./scripts/build_app.sh`
- `codesign --verify --deep --strict --verbose=4 packaging/Pesty.app`
- `codesign -d -r- packaging/Pesty.app`
- Verified the generated binary contains both `arm64` and `x86_64`.
- Rebuilt with `BUILD=2`; the CDHash changed while the designated requirement stayed `designated => identifier "com.greycorelabs.pesty"`.

Tested with `swift build` on Apple Silicon. Intel testing not performed because I don't have access to an Intel Mac.
