### PR TITLE
Wait for shortcut modifiers before direct paste

### DIFF
--- a/Sources/Pesty/Monitor/PasteService.swift
+++ b/Sources/Pesty/Monitor/PasteService.swift
@@ -54,8 +54,11 @@ enum PasteService {
         // Direct-download build: optionally paste straight into the active app by
         // synthesizing ⌘V. This requires the user's Accessibility grant.
         guard Settings.shared.pasteDirectly && AXIsProcessTrusted() else { return }
+        // Let physical shortcut modifiers clear before synthesizing Command-V.
+        // Otherwise the target app can receive the user's original shortcut
+        // instead of a plain paste.
         target.activate()
-        waitForFrontmost(target, attempts: 20)
+        waitForFrontmost(target, attempts: 30)
         #endif
     }
 
@@ -63,12 +66,31 @@ enum PasteService {
     private static func waitForFrontmost(_ app: NSRunningApplication, attempts: Int) {
         guard attempts > 0, !app.isTerminated else { return }
         if NSWorkspace.shared.frontmostApplication?.processIdentifier == app.processIdentifier {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { sendCommandV() }
+            waitForShortcutModifiersToRelease(attempts: 30)
             return
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) {
             waitForFrontmost(app, attempts: attempts - 1)
         }
+    }
+
+    private static func waitForShortcutModifiersToRelease(attempts: Int) {
+        let flags = CGEventSource.flagsState(.combinedSessionState)
+        let shortcutMask = CGEventFlags.maskCommand.rawValue
+            | CGEventFlags.maskAlternate.rawValue
+            | CGEventFlags.maskControl.rawValue
+            | CGEventFlags.maskShift.rawValue
+        let modifiersHeld = flags.rawValue & shortcutMask
+
+        guard modifiersHeld == 0 || attempts == 0 else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
+                waitForShortcutModifiersToRelease(attempts: attempts - 1)
+            }
+            return
+        }
+
+        // Allow the target app one more turn through the run loop after activation.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) { sendCommandV() }
     }
 
     private static func sendCommandV() {


### PR DESCRIPTION
## Summary

- Wait for physical shortcut modifiers to be released before Pesty synthesizes `Command-V`.
- Give the newly activated target app a little more time to become frontmost before sending the paste event.

This avoids a direct paste being interpreted as the still-held shortcut that opened Pesty rather than as a plain paste.

## Validation

- `swift build`

Tested with `swift build` on Apple Silicon. Intel testing not performed because I don't have access to an Intel Mac.
