### PR TITLE
Add a drag handle to resize the Pesty bar

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -150,6 +150,10 @@ final class AppController: NSObject, NSApplicationDelegate {
         barController?.hide()
     }
 
+    func resizeVisibleBar(to height: Double) {
+        barController?.resize(to: CGFloat(height))
+    }
+
     func pasteSelected() {
         guard let item = store.selectedItem else { return }
         hideBar()

--- a/Sources/Pesty/Settings/Settings.swift
+++ b/Sources/Pesty/Settings/Settings.swift
@@ -65,6 +65,7 @@ final class Settings {
             let clamped = min(720, max(240, barHeight))
             if clamped != barHeight { barHeight = clamped; return }
             d.set(barHeight, forKey: Keys.barHeight)
+            AppController.shared.resizeVisibleBar(to: barHeight)
         }
     }
 

--- a/Sources/Pesty/Settings/Settings.swift
+++ b/Sources/Pesty/Settings/Settings.swift
@@ -19,6 +19,7 @@ final class Settings {
         static let playSound = "playSound"
         static let ignoreConcealed = "ignoreConcealed"
         static let barHeight = "barHeight"
+        static let showBarResizeHandle = "showBarResizeHandle"
         static let onboarded = "onboarded"
         static let iCloudSync = "iCloudSync"
     }
@@ -69,6 +70,10 @@ final class Settings {
         }
     }
 
+    var showBarResizeHandle: Bool {
+        didSet { guard isLoaded else { return }; d.set(showBarResizeHandle, forKey: Keys.showBarResizeHandle) }
+    }
+
     var onboarded: Bool {
         didSet { guard isLoaded else { return }; d.set(onboarded, forKey: Keys.onboarded) }
     }
@@ -87,6 +92,7 @@ final class Settings {
             Keys.playSound: false,
             Keys.ignoreConcealed: true,
             Keys.barHeight: 430.0,
+            Keys.showBarResizeHandle: false,
             Keys.onboarded: false,
             Keys.iCloudSync: false
         ])
@@ -98,6 +104,7 @@ final class Settings {
         playSound = d.bool(forKey: Keys.playSound)
         ignoreConcealed = d.bool(forKey: Keys.ignoreConcealed)
         barHeight = d.double(forKey: Keys.barHeight)
+        showBarResizeHandle = d.bool(forKey: Keys.showBarResizeHandle)
         onboarded = d.bool(forKey: Keys.onboarded)
         iCloudSync = d.bool(forKey: Keys.iCloudSync)
         isLoaded = true

--- a/Sources/Pesty/Settings/Settings.swift
+++ b/Sources/Pesty/Settings/Settings.swift
@@ -62,9 +62,9 @@ final class Settings {
 
     var barHeight: Double {
         didSet {
-            guard isLoaded else { return }
-            let clamped = min(720, max(240, barHeight))
+            let clamped = min(720, max(300, barHeight))
             if clamped != barHeight { barHeight = clamped; return }
+            guard isLoaded else { return }
             d.set(barHeight, forKey: Keys.barHeight)
             AppController.shared.resizeVisibleBar(to: barHeight)
         }
@@ -103,7 +103,12 @@ final class Settings {
         pasteDirectly = d.bool(forKey: Keys.pasteDirectly)
         playSound = d.bool(forKey: Keys.playSound)
         ignoreConcealed = d.bool(forKey: Keys.ignoreConcealed)
-        barHeight = d.double(forKey: Keys.barHeight)
+        let storedBarHeight = d.double(forKey: Keys.barHeight)
+        let normalizedBarHeight = min(720, max(300, storedBarHeight))
+        barHeight = normalizedBarHeight
+        if normalizedBarHeight != storedBarHeight {
+            d.set(normalizedBarHeight, forKey: Keys.barHeight)
+        }
         showBarResizeHandle = d.bool(forKey: Keys.showBarResizeHandle)
         onboarded = d.bool(forKey: Keys.onboarded)
         iCloudSync = d.bool(forKey: Keys.iCloudSync)

--- a/Sources/Pesty/Settings/SettingsView.swift
+++ b/Sources/Pesty/Settings/SettingsView.swift
@@ -38,6 +38,7 @@ private struct GeneralSettings: View {
                 Toggle("Ignore passwords (concealed clips)", isOn: $settings.ignoreConcealed)
                 Toggle("Play sound on paste", isOn: $settings.playSound)
                 Toggle("Launch at login", isOn: $settings.launchAtLogin)
+                Toggle("Show resize handle on the Pesty bar", isOn: $settings.showBarResizeHandle)
                 VStack(alignment: .leading) {
                     LabeledContent("Bar height", value: "\(Int(settings.barHeight)) px")
                     Slider(value: $settings.barHeight, in: 300...720, step: 10)

--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -1,9 +1,11 @@
+import AppKit
 import SwiftUI
 
 struct BarView: View {
     @Bindable private var store = ClipboardStore.shared
     @Bindable private var settings = Settings.shared
     @State private var resizeStartHeight: Double?
+    @State private var resizeStartScreenY: CGFloat?
 
     var body: some View {
         ZStack {
@@ -31,15 +33,38 @@ struct BarView: View {
         .frame(height: 14)
         .contentShape(Rectangle())
         .gesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { value in
-                    if resizeStartHeight == nil { resizeStartHeight = settings.barHeight }
-                    guard let start = resizeStartHeight else { return }
-                    settings.barHeight = min(720, max(300, start - value.translation.height))
+            DragGesture(minimumDistance: 0, coordinateSpace: .global)
+                .onChanged { _ in
+                    beginResizeIfNeeded()
+                    guard let height = resizedHeight else { return }
+                    // The panel moves as it resizes, which changes the
+                    // handle's local coordinates. Measure against screen
+                    // coordinates to avoid feeding that movement back into
+                    // the drag calculation.
+                    AppController.shared.resizeVisibleBar(to: height)
                 }
-                .onEnded { _ in resizeStartHeight = nil }
+                .onEnded { _ in
+                    if let height = resizedHeight {
+                        settings.barHeight = height
+                    }
+                    resizeStartHeight = nil
+                    resizeStartScreenY = nil
+                }
         )
         .help("Drag to resize the Pesty bar")
+    }
+
+    private func beginResizeIfNeeded() {
+        guard resizeStartHeight == nil else { return }
+        resizeStartHeight = settings.barHeight
+        resizeStartScreenY = NSEvent.mouseLocation.y
+    }
+
+    private var resizedHeight: Double? {
+        guard let startHeight = resizeStartHeight,
+              let startScreenY = resizeStartScreenY else { return nil }
+        let verticalTravel = Double(NSEvent.mouseLocation.y - startScreenY)
+        return min(720, max(300, startHeight + verticalTravel))
     }
 
     private var topBar: some View {

--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct BarView: View {
     @Bindable private var store = ClipboardStore.shared
     @Bindable private var settings = Settings.shared
+    @State private var resizeStartHeight: Double?
 
     var body: some View {
         ZStack {
@@ -11,12 +12,34 @@ struct BarView: View {
         }
         .overlay(alignment: .top) {
             VStack(spacing: 0) {
+                if settings.showBarResizeHandle { resizeHandle }
                 topBar
                 strip
             }
         }
         .clipShape(RoundedCorners(radius: Theme.cornerRadius, corners: [.topLeft, .topRight]))
         .ignoresSafeArea()
+    }
+
+    private var resizeHandle: some View {
+        HStack {
+            Capsule(style: .continuous)
+                .fill(Theme.textTertiary.opacity(0.7))
+                .frame(width: 42, height: 4)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 14)
+        .contentShape(Rectangle())
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    if resizeStartHeight == nil { resizeStartHeight = settings.barHeight }
+                    guard let start = resizeStartHeight else { return }
+                    settings.barHeight = min(720, max(300, start - value.translation.height))
+                }
+                .onEnded { _ in resizeStartHeight = nil }
+        )
+        .help("Drag to resize the Pesty bar")
     }
 
     private var topBar: some View {

--- a/Sources/Pesty/UI/BarWindowController.swift
+++ b/Sources/Pesty/UI/BarWindowController.swift
@@ -68,6 +68,18 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
         })
     }
 
+    /// Updates the open panel immediately so dragging the resize handle feels
+    /// attached to the bar instead of merely changing a future preference.
+    func resize(to height: CGFloat) {
+        guard let panel = window, panel.isVisible else { return }
+        guard let screen = panel.screen
+                ?? NSScreen.screens.first(where: { $0.frame.intersects(panel.frame) })
+                ?? NSScreen.main else { return }
+        let visible = screen.visibleFrame
+        panel.setFrame(NSRect(x: visible.minX, y: visible.minY,
+                              width: visible.width, height: height), display: true)
+    }
+
     func windowDidResignKey(_ notification: Notification) {
         guard !isPresenting, !AppController.shared.suppressAutoHide else { return }
         AppController.shared.hideBar()


### PR DESCRIPTION
## Summary

- Resize the visible Pesty strip immediately while the Bar height setting changes.
- Keep the resized panel aligned to the active screen's visible frame.

## Validation

- `swift build`

## Screenshots

<img width="3360" height="866" alt="Regular Size Paste Bar" src="https://github.com/user-attachments/assets/f835e018-e3d2-4c6c-b23b-b65adea9092d" />
<br>
<img width="3358" height="1360" alt="Large Paste Bar" src="https://github.com/user-attachments/assets/0cf43cfc-fd57-41dd-a5e5-0d47f4c86a2c" />
<br>
<img width="3354" height="600" alt="Small Paste Bar" src="https://github.com/user-attachments/assets/a34b18d5-0d7c-45f4-acef-b15108385a0f" />
<br>
<img width="964" height="598" alt="Settings Screen" src="https://github.com/user-attachments/assets/327b544c-28e8-47d4-b0f6-ef2eb6f69e1a" />
<br>
<img width="3346" height="108" alt="Drag Handle" src="https://github.com/user-attachments/assets/a0fb1da0-cbd2-48f1-aff9-48ca218fd4c5" />



Tested with `swift build` on Apple Silicon. Intel testing not performed because I don't have access to an Intel Mac.


## Follow-up: resize stability

- Measures the resize drag in screen coordinates, preventing feedback from the panel moving under the pointer.
- Resizes the visible bar live, then persists the final height at drag end.
- Normalizes stored heights to the Settings slider's 300–720px range.

Validation: `swift build`, `git diff --check`.