### PR TITLE
Hide sync control when sync is disabled

### DIFF
--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -21,7 +21,9 @@ struct BarView: View {
 
     private var topBar: some View {
         HStack(spacing: 14) {
-            syncButton
+            if settings.iCloudSync {
+                syncButton
+            }
             searchIndicator
             PinboardTabs()
                 .layoutPriority(1)


### PR DESCRIPTION
## Summary

- Hide the iCloud sync control from the strip when sync is unavailable.
- Keep the existing sync behavior unchanged when it is enabled.

## Validation

- `swift build`

## Screenshots

Sync Not Enabled: 
<img width="3368" height="610" alt="CleanShot 2026-07-23 at 20 58 42@2x" src="https://github.com/user-attachments/assets/00d9bc14-672b-4c22-bc9b-bf3e949f3a9e" />

Sync Enabled: 
<img width="3366" height="610" alt="CleanShot 2026-07-23 at 20 59 07@2x" src="https://github.com/user-attachments/assets/fc4c7797-1abc-446b-ae2a-c7a05b98d9b4" />

## Validation:

Tested with `swift build` on Apple Silicon. Intel testing not performed because I don't have access to an Intel Mac.
