### PR TITLE
Add pause controls and menu icons

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -11,6 +11,7 @@ final class AppController: NSObject, NSApplicationDelegate {
 
     private var barController: BarWindowController?
     private var statusItem: NSStatusItem?
+    private var pauseMenuItem: NSMenuItem?
     private var settingsWindow: NSWindow?
     private var keyMonitor: Any?
 
@@ -64,29 +65,55 @@ final class AppController: NSObject, NSApplicationDelegate {
 
     private func setupStatusItem() {
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        if let button = item.button {
-            button.image = NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: "Pesty")
-            button.image?.isTemplate = true
-        }
+        updateStatusItemIcon(item)
         let menu = NSMenu()
         menu.addItem(withTitle: "Open Pesty   \(Settings.shared.hotkeyDisplay)",
                      action: #selector(menuOpen), keyEquivalent: "").target = self
         menu.addItem(.separator())
-        menu.addItem(withTitle: "Settings…", action: #selector(menuSettings), keyEquivalent: ",").target = self
-        menu.addItem(withTitle: "Clear History", action: #selector(menuClear), keyEquivalent: "").target = self
+        let settings = menu.addItem(withTitle: "Settings…", action: #selector(menuSettings), keyEquivalent: ",")
+        settings.target = self
+        settings.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: nil)
+        let pause = menu.addItem(withTitle: "Pause Pesty", action: #selector(menuTogglePause), keyEquivalent: "")
+        pause.target = self
+        pauseMenuItem = pause
+        let clear = menu.addItem(withTitle: "Clear History", action: #selector(menuClear), keyEquivalent: "")
+        clear.target = self
+        clear.image = NSImage(systemSymbolName: "trash", accessibilityDescription: nil)
         menu.addItem(.separator())
         let about = menu.addItem(withTitle: "About Pesty", action: #selector(menuAbout), keyEquivalent: "")
         about.target = self
-        menu.addItem(withTitle: "Quit Pesty", action: #selector(menuQuit), keyEquivalent: "q").target = self
+        about.image = NSImage(systemSymbolName: "info.circle", accessibilityDescription: nil)
+        let quit = menu.addItem(withTitle: "Quit Pesty", action: #selector(menuQuit), keyEquivalent: "q")
+        quit.target = self
+        quit.image = NSImage(systemSymbolName: "power", accessibilityDescription: nil)
         item.menu = menu
         statusItem = item
+        updatePauseMenuItem()
     }
 
     @objc private func menuOpen() { showBar() }
     @objc private func menuSettings() { showSettings() }
     @objc private func menuClear() { store.clearHistory() }
+    @objc private func menuTogglePause() { togglePestyPause() }
     @objc private func menuQuit() { NSApp.terminate(nil) }
     @objc private func menuAbout() { showAbout() }
+
+    func togglePestyPause() {
+        monitor.togglePause()
+        updatePauseMenuItem()
+        if let item = statusItem { updateStatusItemIcon(item) }
+    }
+
+    private func updatePauseMenuItem() {
+        let paused = monitor.isPaused
+        pauseMenuItem?.title = paused ? "Resume Pesty" : "Pause Pesty"
+        pauseMenuItem?.image = NSImage(systemSymbolName: paused ? "play.fill" : "pause.fill", accessibilityDescription: nil)
+    }
+
+    private func updateStatusItemIcon(_ item: NSStatusItem) {
+        item.button?.image = NSImage(systemSymbolName: monitor.isPaused ? "pause.circle" : "doc.on.clipboard", accessibilityDescription: "Pesty")
+        item.button?.image?.isTemplate = true
+    }
 
     func showAbout() {
         NSApp.activate(ignoringOtherApps: true)

--- a/Sources/Pesty/Monitor/ClipboardMonitor.swift
+++ b/Sources/Pesty/Monitor/ClipboardMonitor.swift
@@ -1,6 +1,8 @@
 import AppKit
 import CryptoKit
+import Observation
 
+@Observable
 @MainActor
 final class ClipboardMonitor {
     private let pasteboard = NSPasteboard.general
@@ -8,6 +10,7 @@ final class ClipboardMonitor {
     private var timer: Timer?
 
     var suppressUntilChangeCount: Int = -1
+    private(set) var isPaused = false
 
     init() {
         lastChangeCount = pasteboard.changeCount
@@ -24,10 +27,13 @@ final class ClipboardMonitor {
 
     func stop() { timer?.invalidate(); timer = nil }
 
+    func togglePause() { isPaused.toggle() }
+
     private func poll() {
         let current = pasteboard.changeCount
         guard current != lastChangeCount else { return }
         lastChangeCount = current
+        guard !isPaused else { return }
         if current == suppressUntilChangeCount { return }
         guard let item = makeItem() else { return }
         ClipboardStore.shared.addCaptured(item)

--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct BarView: View {
     @Bindable private var store = ClipboardStore.shared
     @Bindable private var settings = Settings.shared
+    private var monitor: ClipboardMonitor { AppController.shared.monitor }
 
     var body: some View {
         ZStack {
@@ -69,13 +70,25 @@ struct BarView: View {
 
     private var moreMenu: some View {
         Menu {
-            Button("Settings…") { AppController.shared.showSettings() }
-            Button("Clear History") { store.clearHistory() }
+            Button { AppController.shared.showSettings() } label: {
+                Label("Settings…", systemImage: "gearshape")
+            }
+            Button { AppController.shared.togglePestyPause() } label: {
+                Label(monitor.isPaused ? "Resume Pesty" : "Pause Pesty",
+                      systemImage: monitor.isPaused ? "play.fill" : "pause.fill")
+            }
+            Button { store.clearHistory() } label: {
+                Label("Clear History", systemImage: "trash")
+            }
             Divider()
-            Button("About Pesty") { AppController.shared.showAbout() }
-            Button("Quit Pesty") { NSApp.terminate(nil) }
+            Button { AppController.shared.showAbout() } label: {
+                Label("About Pesty", systemImage: "info.circle")
+            }
+            Button { NSApp.terminate(nil) } label: {
+                Label("Quit Pesty", systemImage: "power")
+            }
         } label: {
-            Image(systemName: "ellipsis")
+            Image(systemName: monitor.isPaused ? "pause.fill" : "ellipsis")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(Theme.textSecondary)
                 .frame(width: 30, height: 30)


### PR DESCRIPTION
## What changed

- Add pause/resume controls for clipboard capture in Pesty's menu bar and bar menu.
- Reflect paused state with clear status and menu icons.

## Why

Users can temporarily stop collection without quitting Pesty and can see that state at a glance.

## Validation

- `swift build`
- `swift build -Xswiftc -DMAS`
- Tested on Apple Silicon. Intel Mac testing was not available.

## Screenshots
**Activate Pause**
<img width="3886" height="1268" alt="CleanShot 2026-07-24 at 10 36 34@2x" src="https://github.com/user-attachments/assets/1c302549-c1b0-4098-9159-1a5be85cd0f4" />

**Paused**
<img width="3886" height="1268" alt="CleanShot 2026-07-24 at 10 36 43@2x" src="https://github.com/user-attachments/assets/a0676b2e-80b3-421e-8cc1-ca387ef5c503" />

**Menubar Paused**
<img width="86" height="64" alt="CleanShot 2026-07-24 at 10 37 06@2x" src="https://github.com/user-attachments/assets/a081e24f-5e2e-4d7e-9b9c-56a48cf01ddc" />

