### PR TITLE
Show feedback after copying a clip

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -13,6 +13,7 @@ final class AppController: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
     private var settingsWindow: NSWindow?
     private var keyMonitor: Any?
+    private let copyToast = CopyToastController()
 
     private(set) var previousApp: NSRunningApplication?
     private(set) var lastActiveApp: NSRunningApplication?
@@ -165,6 +166,15 @@ final class AppController: NSObject, NSApplicationDelegate {
         let change = PasteService.copy(item)
         monitor.suppressUntilChangeCount = change
         hideBar()
+        copyToast.show()
+    }
+
+    func copySelected() {
+        guard let item = store.selectedItem else { return }
+        let change = PasteService.copy(item)
+        monitor.suppressUntilChangeCount = change
+        hideBar()
+        copyToast.show()
     }
 
     func showSettings() {
@@ -217,6 +227,11 @@ final class AppController: NSObject, NSApplicationDelegate {
             return nil
         case kVK_Return, kVK_ANSI_KeypadEnter:
             pasteSelected(); return nil
+        case kVK_ANSI_C:
+            if cmd {
+                copySelected()
+                return nil
+            }
         case kVK_LeftArrow, kVK_UpArrow:
             store.moveSelection(by: -1); return nil
         case kVK_RightArrow, kVK_DownArrow:

--- a/Sources/Pesty/UI/BarWindowController.swift
+++ b/Sources/Pesty/UI/BarWindowController.swift
@@ -1,9 +1,20 @@
 import AppKit
 import SwiftUI
+import Carbon.HIToolbox
 
 final class BarPanel: NSPanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        // AppKit handles Command-key equivalents before SwiftUI receives key-down
+        // events, so copy at the panel level as well as in AppController's monitor.
+        if event.keyCode == kVK_ANSI_C, event.modifierFlags.contains(.command) {
+            AppController.shared.copySelected()
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
 }
 
 @MainActor

--- a/Sources/Pesty/UI/CopyToastController.swift
+++ b/Sources/Pesty/UI/CopyToastController.swift
@@ -1,0 +1,74 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class CopyToastController {
+    private let panel: NSPanel
+    private var dismissWorkItem: DispatchWorkItem?
+
+    init() {
+        panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 236, height: 48),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false)
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.level = .floating
+        panel.ignoresMouseEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        panel.contentView = NSHostingView(rootView: CopyToastView())
+    }
+
+    func show() {
+        dismissWorkItem?.cancel()
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        guard let screen else { return }
+
+        let frame = screen.visibleFrame
+        panel.setFrameOrigin(NSPoint(x: frame.midX - panel.frame.width / 2, y: frame.minY + 34))
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.16
+            panel.animator().alphaValue = 1
+        }
+
+        let dismiss = DispatchWorkItem { [weak self] in self?.dismiss() }
+        dismissWorkItem = dismiss
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.25, execute: dismiss)
+    }
+
+    private func dismiss() {
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.18
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak panel] in
+            panel?.orderOut(nil)
+        })
+    }
+}
+
+private struct CopyToastView: View {
+    var body: some View {
+        HStack(spacing: 9) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(Theme.selection)
+            Text("Copied to Clipboard")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.regularMaterial, in: Capsule(style: .continuous))
+        .overlay {
+            Capsule(style: .continuous)
+                .strokeBorder(.white.opacity(0.28))
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Support copying the selected clip with Command-C while Pesty is open.
- Show a short confirmation toast after copying.
- Handle the command shortcut at the panel level so AppKit key equivalents do not bypass it.

## Why

Copying a clip gets a reliable shortcut and clear feedback without closing Pesty.

## Validation

- `swift build`
- `swift build -Xswiftc -DMAS`
- Tested on Apple Silicon. Intel Mac testing was not available.

## Screenshots
**Paste Bar**
<img width="3886" height="1268" alt="CleanShot 2026-07-24 at 10 44 08@2x" src="https://github.com/user-attachments/assets/0f198524-ea38-4d6f-b918-d68e0008540c" />
**Paste Confirmation**
<img width="824" height="448" alt="CleanShot 2026-07-24 at 10 45 42@2x" src="https://github.com/user-attachments/assets/d1f9770f-4f68-4253-9cff-59c70323939b" />
