### PR TITLE
Adopt Liquid Glass for the Pesty bar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Select Xcode 26.3
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+
       - name: Show toolchain
         run: swift --version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Select Xcode 26.3
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+
       - name: Derive version
         id: ver
         run: echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest. Pesty is a small, native macOS app with no third-party
 ## Prerequisites
 
 - macOS 14 (Sonoma) or later
-- Xcode 16+ / Swift 6 toolchain
+- Xcode 26.3+ / Swift 6 toolchain
 
 ## Build and run
 

--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -6,8 +6,7 @@ struct BarView: View {
 
     var body: some View {
         ZStack {
-            VisualEffectView(material: .hudWindow)
-            Theme.panelTint
+            panelBackground
         }
         .overlay(alignment: .top) {
             VStack(spacing: 0) {
@@ -17,6 +16,16 @@ struct BarView: View {
         }
         .clipShape(RoundedCorners(radius: Theme.cornerRadius, corners: [.topLeft, .topRight]))
         .ignoresSafeArea()
+    }
+
+    @ViewBuilder
+    private var panelBackground: some View {
+        if #available(macOS 26.0, *) {
+            Color.clear
+        } else {
+            VisualEffectView(material: .hudWindow)
+            Theme.panelTint
+        }
     }
 
     private var topBar: some View {

--- a/Sources/Pesty/UI/BarWindowController.swift
+++ b/Sources/Pesty/UI/BarWindowController.swift
@@ -46,6 +46,11 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
     private static let showDuration: TimeInterval = 0.22
     private static let hideDuration: TimeInterval = 0.16
 
+    private static var contentBottomExtension: CGFloat {
+        if #available(macOS 26.0, *) { return Theme.cornerRadius }
+        return 0
+    }
+
     init() {
         let panel = BarPanel(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 360),
@@ -63,7 +68,29 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
         // Without this a stray close() would deallocate the panel and leave `window`
         // nil, which is another way to never show the bar again.
         panel.isReleasedWhenClosed = false
-        panel.contentView = NSHostingView(rootView: BarView())
+        let content = NSHostingView(rootView: BarView())
+        if #available(macOS 26.0, *) {
+            let glassContent = NSView()
+            content.translatesAutoresizingMaskIntoConstraints = false
+            glassContent.addSubview(content)
+            NSLayoutConstraint.activate([
+                content.leadingAnchor.constraint(equalTo: glassContent.leadingAnchor),
+                content.trailingAnchor.constraint(equalTo: glassContent.trailingAnchor),
+                content.topAnchor.constraint(equalTo: glassContent.topAnchor),
+                content.bottomAnchor.constraint(equalTo: glassContent.bottomAnchor,
+                                                constant: -Theme.cornerRadius),
+            ])
+
+            let glass = NSGlassEffectView()
+            glass.contentView = glassContent
+            glass.cornerRadius = Theme.cornerRadius
+            glass.tintColor = NSColor.black.withAlphaComponent(0.12)
+            glass.style = .regular
+            panel.contentView = glass
+            panel.hasShadow = false
+        } else {
+            panel.contentView = content
+        }
         super.init(window: panel)
         panel.delegate = self
     }
@@ -128,8 +155,11 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
         // flew across the bezel. A view clipped to the window can never escape it.
         panel.setFrame(onScreen, display: false)
         guard let content = panel.contentView else { return }
+        let bottomExtension = Self.contentBottomExtension
+        let contentHeight = height + bottomExtension
         content.autoresizingMask = []
-        content.frame = NSRect(x: 0, y: -height, width: onScreen.width, height: height)
+        content.frame = NSRect(x: 0, y: -contentHeight,
+                               width: onScreen.width, height: contentHeight)
 
         let token = beginTransition()
         phase = .showing(token)
@@ -137,7 +167,7 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
         NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
 
-        let finish = { [weak self] in
+        let finish: @MainActor @Sendable () -> Void = { [weak self] in
             guard let self else { return }
             self.settle(token) {
                 self.phase = .shown
@@ -152,7 +182,8 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = Self.showDuration
             ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            content.animator().frame = NSRect(x: 0, y: 0, width: onScreen.width, height: height)
+            content.animator().frame = NSRect(x: 0, y: -bottomExtension,
+                                              width: onScreen.width, height: contentHeight)
         }, completionHandler: { DispatchQueue.main.async(execute: finish) })
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.showDuration + 0.05, execute: finish)
     }
@@ -166,7 +197,7 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
         let down = NSRect(x: 0, y: -content.frame.height,
                           width: content.frame.width, height: content.frame.height)
 
-        let finish = { [weak self] in
+        let finish: @MainActor @Sendable () -> Void = { [weak self] in
             guard let self else { return }
             self.settle(token) {
                 panel.orderOut(nil)


### PR DESCRIPTION
## What changed

- Uses `NSGlassEffectView` for Pesty's bar on macOS 26 and later.
- Extends the glass below the visible panel so only its top corners are rounded.
- Uses the glass tint as the sole macOS 26 scrim and disables the stacked window shadow.
- Preserves the existing visual-effect background on macOS 14–25.
- Selects Xcode 26.3 in CI and release workflows and documents the matching contributor requirement.

## Why

Pesty adopts the native macOS 26 glass material without introducing bottom-edge notches, obscuring the transmission effect, or regressing the newer bar/window behavior on `main`.

## Validation

- `swift build`
- `swift build -Xswiftc -DMAS`
- `VERSION=0.0.0 BUILD=ci ./scripts/build_app.sh`
- `git diff --check`
- Universal arm64/x86_64 bundle verification
- Confirmed both slices retain a macOS 14 minimum deployment target
- Demo-mode visual verification on macOS 26

## Screenshots

**Before**

![Pesty bar before Liquid Glass](https://github.com/user-attachments/assets/2e7b8929-e318-403d-a566-722e620fea5d)

**Updated Liquid Glass — demo mode**

![Updated Pesty Liquid Glass bar](https://raw.githubusercontent.com/alvst/pesty/pr-assets/pr-14-liquid-glass-demo-2026-08-10.jpeg)