### PR TITLE
Polish clip card visual hierarchy

### DIFF
--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -45,7 +45,7 @@ struct BarView: View {
         } label: {
             Image(systemName: settings.iCloudSync ? "checkmark.icloud.fill" : "arrow.triangle.2.circlepath")
                 .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(settings.iCloudSync ? Theme.selection : Theme.textSecondary)
+                .foregroundStyle(settings.iCloudSync ? Theme.selection : Theme.chromeTextSecondary)
         }
         .buttonStyle(.plain)
         .help(settings.iCloudSync ? "iCloud sync on" : "Turn on iCloud sync")
@@ -55,15 +55,15 @@ struct BarView: View {
         HStack(spacing: 6) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(store.searchText.isEmpty ? Theme.textSecondary : Theme.textPrimary)
+                .foregroundStyle(store.searchText.isEmpty ? Theme.chromeTextSecondary : Theme.chromeTextPrimary)
             if !store.searchText.isEmpty {
                 Text(store.searchText)
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(Theme.textPrimary)
+                    .foregroundStyle(Theme.chromeTextPrimary)
                     .lineLimit(1)
                 Button { store.searchText = ""; store.selectFirst() } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 12)).foregroundStyle(Theme.textTertiary)
+                        .font(.system(size: 12)).foregroundStyle(Theme.chromeTextTertiary)
                 }
                 .buttonStyle(.plain)
             }
@@ -84,7 +84,7 @@ struct BarView: View {
         } label: {
             Image(systemName: "ellipsis")
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(Theme.textSecondary)
+                .foregroundStyle(Theme.chromeTextSecondary)
                 .frame(width: 30, height: 30)
         }
         .menuStyle(.borderlessButton)
@@ -107,9 +107,9 @@ struct BarView: View {
                                 removal: .opacity))
                     }
                 }
-                .padding(.horizontal, 18)
-                .padding(.top, 4)
-                .padding(.bottom, 18)
+                .padding(.horizontal, 28)
+                .padding(.top, 16)
+                .padding(.bottom, 26)
                 .animation(.spring(response: 0.34, dampingFraction: 0.8), value: store.visibleItems.count)
             }
             .onChange(of: store.selectedID) { _, id in
@@ -127,12 +127,12 @@ struct BarView: View {
         VStack(spacing: 10) {
             Image(systemName: store.searchText.isEmpty ? "doc.on.clipboard" : "magnifyingglass")
                 .font(.system(size: 34, weight: .light))
-                .foregroundStyle(Theme.textTertiary)
+                .foregroundStyle(Theme.chromeTextTertiary)
             Text(store.searchText.isEmpty
                  ? "Nothing copied yet"
                  : "No matches for “\(store.searchText)”")
                 .font(.system(size: 13))
-                .foregroundStyle(Theme.textSecondary)
+                .foregroundStyle(Theme.chromeTextSecondary)
         }
     }
 }

--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -107,7 +107,7 @@ struct BarView: View {
                                 removal: .opacity))
                     }
                 }
-                .padding(.horizontal, 28)
+                .padding(.horizontal, Theme.cardStripHorizontalPadding)
                 .padding(.top, 16)
                 .padding(.bottom, 26)
                 .animation(.spring(response: 0.34, dampingFraction: 0.8), value: store.visibleItems.count)

--- a/Sources/Pesty/UI/ClipCardView.swift
+++ b/Sources/Pesty/UI/ClipCardView.swift
@@ -16,14 +16,24 @@ struct ClipCardView: View {
         }
         .frame(width: Theme.cardWidth)
         .clipShape(RoundedRectangle(cornerRadius: Theme.cardCorner, style: .continuous))
+        .background {
+            if selected {
+                RoundedRectangle(
+                    cornerRadius: Theme.cardCorner + Theme.selectedCardRing,
+                    style: .continuous
+                )
+                .fill(Theme.selection)
+                .padding(-Theme.selectedCardRing)
+            }
+        }
         .overlay(
             RoundedRectangle(cornerRadius: Theme.cardCorner, style: .continuous)
                 .strokeBorder(selected ? Theme.selection : Theme.cardBorder,
-                              lineWidth: selected ? 2.5 : 1)
+                              lineWidth: selected ? 1.5 : 1)
         )
-        .shadow(color: .black.opacity(selected ? 0.35 : 0.18),
-                radius: selected ? 12 : 5, y: selected ? 5 : 2)
+        .shadow(color: .black.opacity(0.18), radius: 5, y: 2)
         .scaleEffect(hovering && !selected ? 1.015 : 1.0)
+        .zIndex(selected ? 1 : 0)
         .animation(.spring(response: 0.32, dampingFraction: 0.72), value: selected)
         .animation(.easeOut(duration: 0.14), value: hovering)
         .contentShape(Rectangle())
@@ -39,30 +49,35 @@ struct ClipCardView: View {
             HStack(alignment: .top, spacing: 8) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(item.type.label)
-                        .font(.system(size: 14, weight: .bold))
+                        .font(.system(size: 15, weight: .bold))
                         .foregroundStyle(Theme.headerText)
                     Text(item.createdAt.clipRelativeLong)
-                        .font(.system(size: 11))
+                        .font(.system(size: 12))
                         .foregroundStyle(Theme.headerSubText)
                 }
                 .lineLimit(1)
                 Spacer(minLength: 4)
                 appIconTile
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 9)
+            .padding(.horizontal, 13)
+            .padding(.vertical, 7)
         }
         .frame(height: Theme.headerHeight)
     }
 
     private var appIconTile: some View {
-        RoundedRectangle(cornerRadius: 9, style: .continuous)
-            .fill(Color.black.opacity(0.22))
-            .frame(width: 38, height: 38)
+        RoundedRectangle(cornerRadius: 15, style: .continuous)
+            .fill(Color.white.opacity(0.14))
+            .overlay(
+                RoundedRectangle(cornerRadius: 15, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.14))
+            )
+            .frame(width: 56, height: 56)
             .overlay(
                 Image(nsImage: AppIconProvider.icon(forBundleID: item.sourceBundleID))
                     .resizable()
-                    .frame(width: 28, height: 28)
+                    .interpolation(.high)
+                    .frame(width: 48, height: 48)
             )
     }
 
@@ -101,7 +116,7 @@ struct ClipCardView: View {
                 Image(systemName: "doc.fill").font(.system(size: 32))
                     .foregroundStyle(headerColor)
                 Text(item.displayTitle).font(.system(size: 12))
-                    .foregroundStyle(Theme.textSecondary).lineLimit(2)
+                    .foregroundStyle(Theme.cardTextSecondary).lineLimit(2)
                     .multilineTextAlignment(.center)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -109,14 +124,14 @@ struct ClipCardView: View {
             VStack(spacing: 10) {
                 Spacer(minLength: 0)
                 Image(systemName: "safari").font(.system(size: 34, weight: .light))
-                    .foregroundStyle(Theme.textTertiary)
+                    .foregroundStyle(Theme.cardTextTertiary)
                 Spacer(minLength: 0)
             }
             .frame(maxWidth: .infinity)
         default:
             Text(item.text ?? "")
                 .font(.system(size: 12.5))
-                .foregroundStyle(Theme.textPrimary.opacity(0.9))
+                .foregroundStyle(Theme.cardTextPrimary.opacity(0.9))
                 .lineLimit(10)
                 .multilineTextAlignment(.leading)
         }
@@ -124,7 +139,7 @@ struct ClipCardView: View {
 
     private func placeholder(_ symbol: String) -> some View {
         Image(systemName: symbol).font(.system(size: 30))
-            .foregroundStyle(Theme.textTertiary)
+            .foregroundStyle(Theme.cardTextTertiary)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
@@ -133,12 +148,12 @@ struct ClipCardView: View {
             if item.type == .link {
                 Text(item.displayTitle)
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Theme.textPrimary).lineLimit(1)
+                    .foregroundStyle(Theme.cardTextPrimary).lineLimit(1)
             }
             HStack(spacing: 6) {
                 Text(metaLeft)
                     .font(.system(size: 11))
-                    .foregroundStyle(Theme.textSecondary)
+                    .foregroundStyle(Theme.cardTextSecondary)
                     .lineLimit(1)
                 Spacer(minLength: 4)
                 if index < 9 {
@@ -148,7 +163,7 @@ struct ClipCardView: View {
                         Text("\(index + 1)")
                             .font(.system(size: 11, weight: .semibold))
                     }
-                    .foregroundStyle(Theme.textTertiary)
+                    .foregroundStyle(Theme.cardTextTertiary)
                 }
             }
         }

--- a/Sources/Pesty/UI/PinboardTabs.swift
+++ b/Sources/Pesty/UI/PinboardTabs.swift
@@ -30,7 +30,7 @@ struct PinboardTabs: View {
                 Button(action: addPinboard) {
                     Image(systemName: "plus")
                         .font(.system(size: 11, weight: .bold))
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.chromeTextSecondary)
                         .frame(width: 26, height: 26)
                         .background(Theme.fieldBG, in: Circle())
                 }
@@ -55,7 +55,7 @@ struct PinboardTabs: View {
                     .font(.system(size: 12.5, weight: .medium))
                     .lineLimit(1)
             }
-            .foregroundStyle(selected ? Theme.textPrimary : Theme.textSecondary)
+            .foregroundStyle(selected ? Theme.chromeTextPrimary : Theme.chromeTextSecondary)
             .padding(.horizontal, 12)
             .frame(height: 29)
             .background(selected ? Theme.pillSelected : Theme.pillBG, in: Capsule())

--- a/Sources/Pesty/UI/Theme.swift
+++ b/Sources/Pesty/UI/Theme.swift
@@ -2,19 +2,24 @@ import SwiftUI
 
 enum Theme {
     static let cardWidth: CGFloat = 215
-    static let cardSpacing: CGFloat = 12
+    static let cardSpacing: CGFloat = 28
     static let cornerRadius: CGFloat = 16
-    static let cardCorner: CGFloat = 13
-    static let headerHeight: CGFloat = 54
+    static let cardCorner: CGFloat = 19
+    static let headerHeight: CGFloat = 68
 
-    static let panelTint = Color.black.opacity(0.34)
-    static let cardBody = Color(red: 0.11, green: 0.11, blue: 0.12)
-    static let cardBorder = Color.white.opacity(0.07)
-    static let selection = Color(red: 0.20, green: 0.55, blue: 1.0)
+    static let panelTint = Color.white.opacity(0.10)
+    static let cardBody = Color.white.opacity(0.94)
+    static let cardBorder = Color.black.opacity(0.12)
+    static let selection = Color(red: 0.0, green: 0.478, blue: 1.0)
+    static let selectedCardRing: CGFloat = 6
 
-    static let textPrimary = Color.white.opacity(0.95)
-    static let textSecondary = Color.white.opacity(0.55)
-    static let textTertiary = Color.white.opacity(0.34)
+    static let chromeTextPrimary = Color.white.opacity(0.95)
+    static let chromeTextSecondary = Color.white.opacity(0.55)
+    static let chromeTextTertiary = Color.white.opacity(0.34)
+
+    static let cardTextPrimary = Color.black.opacity(0.82)
+    static let cardTextSecondary = Color.black.opacity(0.52)
+    static let cardTextTertiary = Color.black.opacity(0.34)
 
     static let headerText = Color.white
     static let headerSubText = Color.white.opacity(0.78)

--- a/Sources/Pesty/UI/Theme.swift
+++ b/Sources/Pesty/UI/Theme.swift
@@ -12,6 +12,9 @@ enum Theme {
     static let cardBorder = Color.black.opacity(0.12)
     static let selection = Color(red: 0.0, green: 0.478, blue: 1.0)
     static let selectedCardRing: CGFloat = 6
+    // Leave 43 pt beyond the selected-card ring at either strip edge while
+    // preserving the ScrollView's normal clipping behavior.
+    static let cardStripHorizontalPadding: CGFloat = selectedCardRing + 43
 
     static let chromeTextPrimary = Color.white.opacity(0.95)
     static let chromeTextSecondary = Color.white.opacity(0.55)


### PR DESCRIPTION
## What changed

- Give selected cards a clear blue focus ring without increasing their shadow weight.
- Strengthen the card hierarchy with larger source-app icons, clearer headers, lighter card surfaces, and roomier spacing.
- Split shared text colors into `chromeText*` and `cardText*`, keeping the bar controls, empty state, and pinboard tabs readable while card content remains dark on the light card surface.
- Preserve normal scroll clipping while reserving enough strip inset for the selection ring.
- Keep the accepted 16/26-point vertical spacing without folding in the redundant explicit-height geometry from #41.

## Why

The card strip is easier to scan and keyboard selection is clearer, while the appearance-following bar chrome remains readable in Dark Mode.

## Validation

- `swift build`
- `swift build -Xswiftc -DMAS`
- `VERSION=0.0.0 BUILD=ci ./scripts/build_app.sh`
- `git diff --check`
- Universal arm64/x86_64 app bundle verification
- Confirmed both binary slices retain a macOS 14 minimum deployment target
- Demo-mode visual verification with the first card selected at the absolute leading edge

## Screenshots

**Before — original PR revision**

![Original clip-card polish](https://github.com/user-attachments/assets/f9a8fee6-5f3f-4e54-82bc-d530edcbc620)

**After — corrected chrome, selected-card ring, and leading-edge clearance (demo mode)**

![Updated clip-card polish in demo mode](https://raw.githubusercontent.com/alvst/pesty/pr-assets/pr-15-card-polish-demo-2026-08-11.png)
