### PR TITLE
Support dragging clips out of Pesty

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -167,6 +167,14 @@ final class AppController: NSObject, NSApplicationDelegate {
         hideBar()
     }
 
+    func beginDragOut() {
+        // Let AppKit establish the dragging session before taking the source
+        // panel offscreen; the drag can then continue naturally into another app.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) { [weak self] in
+            self?.hideBar()
+        }
+    }
+
     func showSettings() {
         NSApp.activate(ignoringOtherApps: true)
         if let win = settingsWindow {

--- a/Sources/Pesty/UI/ClipCardView.swift
+++ b/Sources/Pesty/UI/ClipCardView.swift
@@ -30,6 +30,10 @@ struct ClipCardView: View {
         .onHover { hovering = $0 }
         .onTapGesture(count: 2) { AppController.shared.pasteItem(item) }
         .onTapGesture { store.selectedID = item.id }
+        .onDrag {
+            AppController.shared.beginDragOut()
+            return ClipDragProvider.make(for: item)
+        }
         .contextMenu { menu }
     }
 

--- a/Sources/Pesty/Util/ClipDragProvider.swift
+++ b/Sources/Pesty/Util/ClipDragProvider.swift
@@ -1,0 +1,47 @@
+import AppKit
+import UniformTypeIdentifiers
+
+@MainActor
+enum ClipDragProvider {
+    static func make(for item: ClipItem) -> NSItemProvider {
+        switch item.type {
+        case .image:
+            if let image = ClipboardStore.shared.loadImage(for: item),
+               let tiff = image.tiffRepresentation,
+               let bitmap = NSBitmapImageRep(data: tiff),
+               let png = bitmap.representation(using: .png, properties: [:]) {
+                let provider = NSItemProvider()
+                register(png, as: .png, on: provider)
+                register(tiff, as: .tiff, on: provider)
+                provider.suggestedName = item.displayTitle
+                return provider
+            }
+        case .file:
+            if let url = item.fileURLs.first.flatMap(URL.init(string:)), url.isFileURL {
+                return NSItemProvider(object: url as NSURL)
+            }
+        case .richText:
+            if let rtf = item.rtfData {
+                let provider = NSItemProvider()
+                register(rtf, as: .rtf, on: provider)
+                register(Data((item.text ?? "").utf8), as: .utf8PlainText, on: provider)
+                provider.suggestedName = item.displayTitle
+                return provider
+            }
+        case .text, .link, .color:
+            break
+        }
+
+        let provider = NSItemProvider()
+        register(Data((item.text ?? item.colorHex ?? item.displayTitle).utf8), as: .utf8PlainText, on: provider)
+        provider.suggestedName = item.displayTitle
+        return provider
+    }
+
+    private static func register(_ data: Data, as type: UTType, on provider: NSItemProvider) {
+        provider.registerDataRepresentation(forTypeIdentifier: type.identifier, visibility: .all) { completion in
+            completion(data, nil)
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Make clip cards draggable.
- Export text, links, colors, rich text, images, and file URLs with appropriate pasteboard representations.
- Hide Pesty after the drag session begins so the destination app can receive the drop.

## Why

Clips can be moved directly into another app instead of being limited to copy/paste.

## Validation

- `swift build`
- `swift build -Xswiftc -DMAS`
- Tested on Apple Silicon. Intel Mac testing was not available.

## Screenshots

<img width="647" height="526" alt="image" src="https://github.com/user-attachments/assets/3ee7668f-f99e-4bef-b185-fb912625c2e7" />


Note: The paste bar gets minimized when the drag optation begins so that if you are dragging to below the paste bar, you can drop there. 
