### PR TITLE
Reset the clip strip when Pesty opens

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -136,7 +136,7 @@ final class AppController: NSObject, NSApplicationDelegate {
         }
         store.searchText = ""
         store.source = .history
-        store.selectFirst()
+        store.prepareForBarPresentation()
 
         if barController == nil {
             barController = BarWindowController()

--- a/Sources/Pesty/Store/ClipboardStore.swift
+++ b/Sources/Pesty/Store/ClipboardStore.swift
@@ -17,6 +17,9 @@ final class ClipboardStore {
     var source: BarSource = .history
     var searchText: String = ""
     var selectedID: UUID?
+    /// Lets the strip restore its opening position without animating from the
+    /// card that happened to be selected when Pesty was last hidden.
+    var initialScrollTargetID: UUID?
 
     var historyLimit: Int {
         get { Settings.shared.historyLimit }
@@ -171,6 +174,12 @@ final class ClipboardStore {
     }
 
     func selectFirst() { selectedID = visibleItems.first?.id }
+
+    func prepareForBarPresentation() {
+        let firstID = visibleItems.first?.id
+        initialScrollTargetID = firstID
+        selectedID = firstID
+    }
 
     func moveSelection(by delta: Int) {
         let items = visibleItems

--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -107,6 +107,15 @@ struct BarView: View {
             }
             .onChange(of: store.selectedID) { _, id in
                 guard let id else { return }
+                if store.initialScrollTargetID == id {
+                    store.initialScrollTargetID = nil
+                    var transaction = Transaction()
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) {
+                        proxy.scrollTo(id, anchor: .leading)
+                    }
+                    return
+                }
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.78)) {
                     proxy.scrollTo(id, anchor: .center)
                 }


### PR DESCRIPTION
## What changed

- Return the strip to its first clip when Pesty opens.
- Restore that initial position without an unnecessary scroll animation.

## Why

Reopening Pesty starts from a predictable, uncluttered strip position instead of the card selected during the previous session.

## Validation

- `swift build`
- `swift build -Xswiftc -DMAS`
- Tested on Apple Silicon. Intel Mac testing was not available.

## Screenshots

Currently selected item is the 6th item
<img width="3888" height="1268" alt="CleanShot 2026-07-24 at 11 45 14@2x" src="https://github.com/user-attachments/assets/fb385665-4a86-48eb-a903-b6b98a5314e5" />

Reopened Pesty and reverted to the first item
<img width="3888" height="1268" alt="CleanShot 2026-07-24 at 11 45 34@2x" src="https://github.com/user-attachments/assets/16db981c-0e3c-4c6c-8e42-9c94be7a971b" />
