### PR TITLE
Delete the selected clip with Backspace

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -226,6 +226,7 @@ final class AppController: NSObject, NSApplicationDelegate {
             if !store.searchText.isEmpty {
                 store.searchText.removeLast(); store.selectFirst(); return nil
             }
+            if let sel = store.selectedItem { store.delete(sel) }
             return nil
         case kVK_ForwardDelete:
             if let sel = store.selectedItem { store.delete(sel) }


### PR DESCRIPTION
## What changed

- Delete the selected clip when Backspace is pressed and Pesty is not editing a search query.

## Why

Backspace now behaves consistently with Forward Delete and makes keyboard cleanup faster.

## Screenshot 
Not applicable

## Validation

- `swift build`
- `swift build -Xswiftc -DMAS`
- Tested on Apple Silicon. Intel Mac testing was not available.