### PR TITLE
Animate Pesty bar dismissal when switching apps

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -19,6 +19,12 @@ final class AppController: NSObject, NSApplicationDelegate {
 
     var suppressAutoHide = false
 
+    func applicationWillResignActive(_ notification: Notification) {
+        // Begin the slide-down before the next app becomes active. Starting
+        // after that handoff can prevent the panel animation from rendering.
+        hideBar()
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
 

--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -55,6 +55,12 @@ final class AppController: NSObject, NSApplicationDelegate {
         guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
         if app.bundleIdentifier != Bundle.main.bundleIdentifier {
             lastActiveApp = app
+            // Command-Tab and app switching do not reliably make our borderless
+            // panel resign key. Treat activation of another app as an explicit
+            // dismissal so the bar never stays above the newly active app.
+            if barController?.window?.isVisible == true {
+                hideBar()
+            }
         }
     }
 

--- a/Sources/Pesty/UI/BarWindowController.swift
+++ b/Sources/Pesty/UI/BarWindowController.swift
@@ -10,6 +10,8 @@ final class BarPanel: NSPanel {
 final class BarWindowController: NSWindowController, NSWindowDelegate {
 
     private var isPresenting = false
+    private var isDismissing = false
+    private var transitionID = 0
 
     init() {
         let panel = BarPanel(
@@ -34,6 +36,8 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
 
     func show() {
         guard let panel = window else { return }
+        transitionID &+= 1
+        isDismissing = false
         isPresenting = true
         guard let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
             ?? NSScreen.main ?? NSScreen.screens.first else { isPresenting = false; return }
@@ -56,15 +60,22 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
     }
 
     func hide() {
-        guard let panel = window, panel.isVisible else { return }
+        guard let panel = window, panel.isVisible, !isDismissing else { return }
+        isDismissing = true
+        transitionID &+= 1
+        let hideTransitionID = transitionID
         let off = NSRect(x: panel.frame.minX, y: panel.frame.minY - panel.frame.height,
                          width: panel.frame.width, height: panel.frame.height)
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = 0.16
             ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
             panel.animator().setFrame(off, display: true)
-        }, completionHandler: {
-            panel.orderOut(nil)
+        }, completionHandler: { [weak self] in
+            DispatchQueue.main.async {
+                guard let self, self.transitionID == hideTransitionID else { return }
+                panel.orderOut(nil)
+                self.isDismissing = false
+            }
         })
     }
 


### PR DESCRIPTION
## Summary

- Hide the Paste Bar whenever another app becomes active.
- Start the slide-down before Pesty loses active status, so Command-Tab renders the dismissal rather than abruptly removing the bar.
- Ignore duplicate dismissal events and prevent a stale animation completion from hiding a newly reopened bar.

## Root cause

Command-Tab could trigger both the key-resign and workspace-activation paths. They started overlapping hide animations, with the later app switch often preventing the animation from being composited.

## Validation

- `swift build`

Static screenshots are not applicable to this transition behavior.
