### PR TITLE
Add a Quit action to Settings

### DIFF
--- a/Sources/Pesty/Settings/SettingsView.swift
+++ b/Sources/Pesty/Settings/SettingsView.swift
@@ -130,6 +130,10 @@ private struct AboutView: View {
                 Link("Report an Issue", destination: URL(string: "https://github.com/momenbasel/pesty/issues")!)
             }
             .padding(.top, 4)
+            Button("Quit Pesty", role: .destructive) {
+                NSApp.terminate(nil)
+            }
+            .padding(.top, 8)
             Spacer()
             Text("MIT Licensed · Made with SwiftUI")
                 .font(.caption).foregroundStyle(.tertiary)


### PR DESCRIPTION
## What changed

- Add a destructive “Quit Pesty” action to the Settings About tab.

## Why

Users can quit Pesty from the same place they inspect app information, without needing to find the menu-bar item.

## Validation

- `swift build`
- `swift build -Xswiftc -DMAS`
- Tested on Apple Silicon. Intel Mac testing was not available.