### PR TITLE
Use native switches in Settings

### DIFF
--- a/Sources/Pesty/Settings/SettingsView.swift
+++ b/Sources/Pesty/Settings/SettingsView.swift
@@ -34,10 +34,14 @@ private struct GeneralSettings: View {
             Section("Behavior") {
                 #if !MAS
                 Toggle("Paste directly into the active app", isOn: $settings.pasteDirectly)
+                    .toggleStyle(.switch)
                 #endif
                 Toggle("Ignore passwords (concealed clips)", isOn: $settings.ignoreConcealed)
+                    .toggleStyle(.switch)
                 Toggle("Play sound on paste", isOn: $settings.playSound)
+                    .toggleStyle(.switch)
                 Toggle("Launch at login", isOn: $settings.launchAtLogin)
+                    .toggleStyle(.switch)
                 VStack(alignment: .leading) {
                     LabeledContent("Bar height", value: "\(Int(settings.barHeight)) px")
                     Slider(value: $settings.barHeight, in: 300...720, step: 10)
@@ -52,6 +56,7 @@ private struct GeneralSettings: View {
                 Toggle("Sync clipboard via iCloud Drive", isOn: Binding(
                     get: { settings.iCloudSync },
                     set: { _ in AppController.shared.toggleICloudSync() }))
+                    .toggleStyle(.switch)
                 Text(ClipboardStore.shared.iCloudAvailable
                      ? "Keeps your history and pinboards in sync across your Macs through iCloud Drive."
                      : "Sign in to iCloud and enable iCloud Drive to use sync.")


### PR DESCRIPTION
## What changed

- Render Boolean preferences as native macOS switches in Settings.

## Why

The control style makes on/off preferences easier to recognize and matches the rest of the macOS interface.

## Validation

- swift build
- swift build -Xswiftc -DMAS
- Tested on Apple Silicon. Intel Mac testing was not available.

## Screenshots

Demo mode; Pesty window only.

<img width="520" height="592" alt="Pesty Settings showing native switches" src="https://github.com/user-attachments/assets/7717caf7-b0df-41bc-98b9-74ff949a0f53" />