### PR TITLE
docs: clarify when screenshots belong in pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,13 @@ open packaging/Pesty.app
 - Keep it dependency-free. Prefer system frameworks (AppKit, SwiftUI, Carbon, ServiceManagement).
 - Match the existing style. Small, focused changes; no unrelated refactors in the same PR.
 - Test on both Apple Silicon and Intel where it matters (the release is universal).
-- UI changes: include a before/after screenshot of the strip.
+- Screenshots: add them when a user-facing UI change needs visual context or when they make review easier; they are not required for every change.
 
 ## Pull requests
 
 1. Fork and branch from `main`.
 2. Make your change; ensure `swift build` is clean (no warnings).
-3. Open a PR with a clear description and screenshots for UI changes.
+3. Open a PR with a clear description and any screenshots that are useful for review.
 
 ## Good first issues
 


### PR DESCRIPTION
## What changed

- Clarifies that screenshots belong in a pull request when they add useful UI context or help reviewers evaluate a change, rather than for every change.
- Updates the pull-request checklist accordingly.

## Why

This keeps the contribution guidance aligned with practical review needs while avoiding meaningless image churn.

## Validation

- `git diff --check`