### PR TITLE
Show the Paste Bar on launch and reopen

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -13,6 +13,7 @@ final class AppController: NSObject, NSApplicationDelegate {
     private var statusItem: NSStatusItem?
     private var settingsWindow: NSWindow?
     private var keyMonitor: Any?
+    private var isReopenPresentationPending = false
 
     private(set) var previousApp: NSRunningApplication?
     private(set) var lastActiveApp: NSRunningApplication?
@@ -49,6 +50,33 @@ final class AppController: NSObject, NSApplicationDelegate {
             }
             Settings.shared.onboarded = true
         }
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication,
+                                       hasVisibleWindows flag: Bool) -> Bool {
+        // Finder, Spotlight, and the Dock send a reopen event when the user
+        // invokes an app that is already running. The clipboard bar is an
+        // NSPanel, so AppKit's `hasVisibleWindows` value does not reliably
+        // describe whether Pesty already has a surface on screen.
+        guard !hasVisiblePestySurface else { return true }
+        guard !isReopenPresentationPending else { return false }
+
+        isReopenPresentationPending = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.isReopenPresentationPending = false
+
+            // A window can appear while AppKit finishes the reopen event
+            // (for example, during onboarding). Avoid presenting a second
+            // Pesty surface in that case.
+            guard !self.hasVisiblePestySurface else { return }
+            self.showBar()
+        }
+        return false
+    }
+
+    private var hasVisiblePestySurface: Bool {
+        NSApp.windows.contains { $0.isVisible && !$0.isMiniaturized }
     }
 
     @objc private func appActivated(_ note: Notification) {
@@ -133,6 +161,10 @@ final class AppController: NSObject, NSApplicationDelegate {
         let front = NSWorkspace.shared.frontmostApplication
         if front?.bundleIdentifier != Bundle.main.bundleIdentifier {
             previousApp = front
+        } else if let lastActiveApp, !lastActiveApp.isTerminated {
+            // Reopen events arrive after Pesty becomes active, so retain the
+            // most recently active non-Pesty app as the eventual paste target.
+            previousApp = lastActiveApp
         }
         store.searchText = ""
         store.source = .history

--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -44,11 +44,13 @@ final class AppController: NSObject, NSApplicationDelegate {
             return
         }
 
+        // Pesty's primary interface should be immediately discoverable after
+        // every normal launch, including the first launch after quitting.
         if !Settings.shared.onboarded {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
-                self?.showSettings()
-            }
             Settings.shared.onboarded = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.showBar()
         }
     }
 
@@ -58,7 +60,9 @@ final class AppController: NSObject, NSApplicationDelegate {
         // invokes an app that is already running. The clipboard bar is an
         // NSPanel, so AppKit's `hasVisibleWindows` value does not reliably
         // describe whether Pesty already has a surface on screen.
-        guard !hasVisiblePestySurface else { return true }
+        // Settings and previews are secondary surfaces. Only an already
+        // visible Paste Bar should suppress a new presentation.
+        guard !isBarVisible else { return true }
         guard !isReopenPresentationPending else { return false }
 
         isReopenPresentationPending = true
@@ -66,17 +70,16 @@ final class AppController: NSObject, NSApplicationDelegate {
             guard let self else { return }
             self.isReopenPresentationPending = false
 
-            // A window can appear while AppKit finishes the reopen event
-            // (for example, during onboarding). Avoid presenting a second
-            // Pesty surface in that case.
-            guard !self.hasVisiblePestySurface else { return }
+            // A duplicate reopen event can arrive while AppKit finishes the
+            // first one. Avoid presenting the Paste Bar twice.
+            guard !self.isBarVisible else { return }
             self.showBar()
         }
         return false
     }
 
-    private var hasVisiblePestySurface: Bool {
-        NSApp.windows.contains { $0.isVisible && !$0.isMiniaturized }
+    private var isBarVisible: Bool {
+        barController?.window?.isVisible == true
     }
 
     @objc private func appActivated(_ note: Notification) {


### PR DESCRIPTION
## Summary

- Show the Paste Bar after every normal launch, including the first launch after quitting Pesty.
- Show the Paste Bar when Pesty is reopened from Finder, Spotlight, or the Dock while it is hidden.
- Treat only the visible Paste Bar as already presented; Settings and preview windows no longer block reopening it.

## Why

Pesty's primary interface should be discoverable without requiring the keyboard shortcut.

## Validation

- `swift build`
- Manual macOS verification: hide the Paste Bar, reopen `Pesty.app`, and confirm the bar returns.
