### PR TITLE
Fix bar rendering on the wrong display in multi-monitor setups

### DIFF
--- a/Sources/Pesty/UI/BarWindowController.swift
+++ b/Sources/Pesty/UI/BarWindowController.swift
@@ -64,39 +64,41 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
         let vf = screen.visibleFrame
         let height = min(CGFloat(Settings.shared.barHeight), vf.height)
         let onScreen = NSRect(x: vf.minX, y: vf.minY, width: vf.width, height: height)
-        let offScreen = NSRect(x: vf.minX, y: vf.minY - height, width: vf.width, height: height)
 
-        // A hide() still animating owns the panel's frame. Repositioning under it makes
-        // the panel interpolate from the old display's frame to the new one, so it
-        // visibly flies across screens instead of sliding up. A zero-duration animation
-        // replaces the in-flight one before we stage the slide.
+        // The panel stays parked at its final frame and the content slides up *inside*
+        // it. Animating the window frame itself is not safe on multi-display setups:
+        // the old staging rect (vf.minY - height) is only genuinely off-screen when
+        // nothing sits below the target display. With displays stacked vertically it
+        // lands on the neighbouring screen, so the bar appeared there in full and then
+        // flew across the bezel. A view clipped to the window can never escape it.
         isHiding = false
-        NSAnimationContext.runAnimationGroup { ctx in
-            ctx.duration = 0
-            panel.animator().setFrame(offScreen, display: false)
-        }
-        panel.setFrame(offScreen, display: false)
+        panel.setFrame(onScreen, display: false)
+        guard let content = panel.contentView else { isPresenting = false; return }
+        content.autoresizingMask = []
+        content.frame = NSRect(x: 0, y: -height, width: onScreen.width, height: height)
+
         NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
 
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = 0.22
             ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            panel.animator().setFrame(onScreen, display: true)
+            content.animator().frame = NSRect(x: 0, y: 0, width: onScreen.width, height: height)
         }, completionHandler: { [weak self] in
             DispatchQueue.main.async { self?.isPresenting = false }
         })
     }
 
     func hide() {
-        guard let panel = window, panel.isVisible, !isHiding else { return }
+        guard let panel = window, panel.isVisible, !isHiding,
+              let content = panel.contentView else { return }
         isHiding = true
-        let off = NSRect(x: panel.frame.minX, y: panel.frame.minY - panel.frame.height,
-                         width: panel.frame.width, height: panel.frame.height)
+        let down = NSRect(x: 0, y: -content.frame.height,
+                          width: content.frame.width, height: content.frame.height)
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = 0.16
             ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
-            panel.animator().setFrame(off, display: true)
+            content.animator().frame = down
         }, completionHandler: { [weak self] in
             DispatchQueue.main.async {
                 // show() may have re-staged the panel mid-animation; only retire it if

--- a/Sources/Pesty/UI/BarWindowController.swift
+++ b/Sources/Pesty/UI/BarWindowController.swift
@@ -10,6 +10,7 @@ final class BarPanel: NSPanel {
 final class BarWindowController: NSWindowController, NSWindowDelegate {
 
     private var isPresenting = false
+    private var isHiding = false
 
     init() {
         let panel = BarPanel(
@@ -32,16 +33,48 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
 
     required init?(coder: NSCoder) { fatalError("init(coder:) unavailable") }
 
+    /// The screen the bar should slide up from: the one under the pointer.
+    ///
+    /// `NSRect.contains` excludes a rect's max edges, so a pointer sitting exactly on
+    /// the boundary between two displays matches none of them. Displays of differing
+    /// sizes also leave unreachable gaps in the global coordinate space. Both cases
+    /// used to fall through to `NSScreen.main`, which is the screen holding the *key
+    /// window* — not the one the pointer is on — so the bar surfaced on the wrong
+    /// display. Hit-test with `NSMouseInRect`, then fall back to the nearest screen.
+    private static func targetScreen() -> NSScreen? {
+        let mouse = NSEvent.mouseLocation
+        if let hit = NSScreen.screens.first(where: { NSMouseInRect(mouse, $0.frame, false) }) {
+            return hit
+        }
+        return NSScreen.screens.min { a, b in
+            distanceSquared(from: a.frame, to: mouse) < distanceSquared(from: b.frame, to: mouse)
+        }
+    }
+
+    private static func distanceSquared(from rect: NSRect, to point: NSPoint) -> CGFloat {
+        let dx = max(rect.minX - point.x, 0, point.x - rect.maxX)
+        let dy = max(rect.minY - point.y, 0, point.y - rect.maxY)
+        return dx * dx + dy * dy
+    }
+
     func show() {
         guard let panel = window else { return }
         isPresenting = true
-        guard let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
-            ?? NSScreen.main ?? NSScreen.screens.first else { isPresenting = false; return }
+        guard let screen = Self.targetScreen() else { isPresenting = false; return }
         let vf = screen.visibleFrame
-        let height = CGFloat(Settings.shared.barHeight)
+        let height = min(CGFloat(Settings.shared.barHeight), vf.height)
         let onScreen = NSRect(x: vf.minX, y: vf.minY, width: vf.width, height: height)
         let offScreen = NSRect(x: vf.minX, y: vf.minY - height, width: vf.width, height: height)
 
+        // A hide() still animating owns the panel's frame. Repositioning under it makes
+        // the panel interpolate from the old display's frame to the new one, so it
+        // visibly flies across screens instead of sliding up. A zero-duration animation
+        // replaces the in-flight one before we stage the slide.
+        isHiding = false
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0
+            panel.animator().setFrame(offScreen, display: false)
+        }
         panel.setFrame(offScreen, display: false)
         NSApp.activate(ignoringOtherApps: true)
         panel.makeKeyAndOrderFront(nil)
@@ -56,15 +89,22 @@ final class BarWindowController: NSWindowController, NSWindowDelegate {
     }
 
     func hide() {
-        guard let panel = window, panel.isVisible else { return }
+        guard let panel = window, panel.isVisible, !isHiding else { return }
+        isHiding = true
         let off = NSRect(x: panel.frame.minX, y: panel.frame.minY - panel.frame.height,
                          width: panel.frame.width, height: panel.frame.height)
         NSAnimationContext.runAnimationGroup({ ctx in
             ctx.duration = 0.16
             ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
             panel.animator().setFrame(off, display: true)
-        }, completionHandler: {
-            panel.orderOut(nil)
+        }, completionHandler: { [weak self] in
+            DispatchQueue.main.async {
+                // show() may have re-staged the panel mid-animation; only retire it if
+                // this hide is still the one in flight.
+                guard self?.isHiding == true else { return }
+                self?.isHiding = false
+                panel.orderOut(nil)
+            }
         })
     }
 


### PR DESCRIPTION
## The problem

On a multi-display setup the bar appears on a *different* screen than the one it targets, and visibly flies across the bezel instead of sliding up from the bottom.

Reproduced on macOS 26 with three non-mirrored displays at mixed scale factors.

## Root cause

`show()` staged the panel one bar-height below its final position and animated the **window frame** up:

```swift
let onScreen  = NSRect(x: vf.minX, y: vf.minY, width: vf.width, height: height)
let offScreen = NSRect(x: vf.minX, y: vf.minY - height, width: vf.width, height: height)
panel.setFrame(offScreen, display: false)
```

`vf.minY - height` is only genuinely off-screen when **nothing sits below the target display**. macOS lays all screens out in one global coordinate space, so with displays stacked vertically that rect lands on the neighbouring monitor.

Here is the reporting machine's layout:

```
[0] internal   frame x=0     y=0     w=1728 h=1117   visibleFrame minY=0
[1] external   frame x=-832  y=1117  w=2560 h=1440   visibleFrame minY=1117
[2] portrait   frame x=1728  y=-26   w=1080 h=1920   visibleFrame minY=-26
```

Screen [1] sits directly on top of screen [0] — [0] spans y 0→1117 and [1] starts at exactly y=1117. Targeting screen [1] with the default `barHeight` of 370 stages the panel at **y = 1117 − 370 = 747**, which is squarely inside screen [0]. The bar rendered in full on the internal display, then animated upward across the bezel onto the external one.

This is not a screen-*selection* bug — the existing hit-test correctly returns screen [1]. The staging rectangle itself is the problem, and it will misbehave for any arrangement with a display below the target.

## The fix

Park the panel at its final frame and animate the **content view** from `y = -height` to `y = 0` inside it. A content view is clipped to its window, so nothing can render outside the target screen for any display arrangement. `hide()` reverses the same offset before ordering the panel out. The slide-up feel is unchanged.

While in here, two smaller issues on the same path:

- **Screen selection fallback.** `NSRect.contains` excludes a rect's max edges, so a pointer exactly on a display boundary matched no screen; displays of differing sizes also leave gaps in the global coordinate space. Both fell through to `NSScreen.main`, which is the screen holding the *key window*, not the one under the pointer. Now hit-tested with `NSMouseInRect` and falling back to the nearest screen.
- **Re-entrancy.** `hide()` only calls `orderOut` in its completion handler, so a `show()` arriving within that 0.16s window raced it. `hide()` is now guarded against re-entry and retires the panel only if its own animation is still the one in flight.

Bar height is also clamped to the target screen's `visibleFrame` so a tall configured height can't overshoot a short display.

## Testing

- `swift build` clean — no warnings, no errors.
- `./scripts/build_app.sh` produces a working universal bundle (arm64 + x86_64).
- **Confirmed fixed on the three-display setup above** by the reporter, across all three screens including the portrait one.
- Single-display behavior unchanged.

No screenshot — the change is cross-display positioning rather than a visual change to the strip, and a still frame doesn't capture it. Happy to record a screen capture if useful.