### PR TITLE
docs: carve out a no-visual-delta exception for screenshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,13 @@ open packaging/Pesty.app
 - Keep it dependency-free. Prefer system frameworks (AppKit, SwiftUI, Carbon, ServiceManagement).
 - Match the existing style. Small, focused changes; no unrelated refactors in the same PR.
 - Test on both Apple Silicon and Intel where it matters (the release is universal).
-- UI changes: include a before/after screenshot of the strip.
+- UI changes: include a before/after screenshot of the strip. If the change has no visual delta (refactor, accessibility labels, focus order), say so in the PR description instead.
 
 ## Pull requests
 
 1. Fork and branch from `main`.
 2. Make your change; ensure `swift build` is clean (no warnings).
-3. Open a PR with a clear description and screenshots for UI changes.
+3. Open a PR with a clear description and, for UI changes, before/after screenshots of the strip.
 
 ## Good first issues
 


### PR DESCRIPTION
Supersedes #36 with the narrow carve-out agreed in review: the before/after-screenshot rule for UI changes stays, and PRs with no visual delta (refactor, accessibility labels, focus order) say so in the description instead.

Credit to @alvst for raising it in #36.

— automated maintainer pass on behalf of @momenbasel

Made with [Cursor](https://cursor.com)