### PR TITLE
Show the Paste Bar when Pesty is reopened

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -77,19 +77,30 @@ final class AppController: NSObject, NSApplicationDelegate {
         store.saveNow()
     }
 
-    /// The escape hatch for a hidden menu bar icon.
+    /// Reopening from Finder, Spotlight, or the Dock surfaces the app.
     ///
-    /// Pesty is an accessory app, so with the status item hidden there is no Dock icon,
-    /// no window, and no menu - and if the global hotkey failed to register because
-    /// another app already owns the combination, there is no way back in at all short of
-    /// deleting the preference from Terminal. Opening Pesty again from Finder or
-    /// Spotlight brings the icon back and shows Settings.
+    /// The escape hatch comes first: Pesty is an accessory app, so with the status
+    /// item hidden there is no Dock icon, no window, and no menu - and if the global
+    /// hotkey failed to register because another app already owns the combination,
+    /// there is no way back in at all short of deleting the preference from Terminal.
+    /// Opening Pesty again brings the icon back and shows Settings so the user can
+    /// fix whatever forced the relaunch.
+    ///
+    /// A normal reopen shows the Paste Bar - the primary interface should be
+    /// discoverable without the keyboard shortcut. `hasVisibleWindows` cannot be
+    /// trusted for that decision because the bar is an NSPanel, so ask the explicit
+    /// presentation state instead; a duplicate reopen event coalesces naturally
+    /// because `isPresented` flips as soon as the first show begins.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
         if !Settings.shared.showMenuBarIcon {
             Settings.shared.showMenuBarIcon = true
             setMenuBarIconVisible(true)
+            showSettings()
+            return true
         }
-        showSettings()
+        if barController?.isPresented != true {
+            showBar()
+        }
         return true
     }
 


### PR DESCRIPTION
Lands the reopen half of #38, folded into the existing reopen handler as the Aug 11 review requested:

- Normal reopen (Finder / Spotlight / Dock) shows the Paste Bar when it is not already presented, gated on `barController.isPresented` (the #64 state machine) rather than `NSWindow.isVisible`.
- The hidden-menu-bar escape hatch keeps restoring the icon and showing Settings — that path is recovery, not a bar request.
- The launch-time auto-show and the onboarding removal from #38 are deliberately **not** included (rejected in review: login-item focus stealing, and Settings is the only surface that requests Accessibility).

Paste-target staleness on the reopen path is already covered by `pasteTarget` from #66.

Credit to @alvst — extracted and reworked from #38.

— automated maintainer pass on behalf of @momenbasel

Made with [Cursor](https://cursor.com)