### PR TITLE
Reset the clip strip to its start when the bar presents

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -223,7 +223,7 @@ final class AppController: NSObject, NSApplicationDelegate {
         }
         store.searchText = ""
         store.source = .history
-        store.selectFirst()
+        store.prepareForBarPresentation()
 
         // Rebuild if the panel was ever torn down - a nil window is another way the
         // bar silently stops appearing.

--- a/Sources/Pesty/Store/ClipboardStore.swift
+++ b/Sources/Pesty/Store/ClipboardStore.swift
@@ -22,6 +22,12 @@ final class ClipboardStore {
     var searchText: String = ""
     var selectedID: UUID?
 
+    /// Bumped every time the bar is about to present. The hosting view is
+    /// built once and cached, so the strip keeps its scroll offset across
+    /// hide/show; selection alone cannot reset it because the newest clip is
+    /// usually already selected and `onChange` never fires for equal values.
+    private(set) var barPresentationToken = 0
+
     var historyLimit: Int {
         get { Settings.shared.historyLimit }
         set { Settings.shared.historyLimit = newValue; trimHistory() }
@@ -202,6 +208,11 @@ final class ClipboardStore {
     }
 
     func selectFirst() { selectedID = visibleItems.first?.id }
+
+    func prepareForBarPresentation() {
+        barPresentationToken &+= 1
+        selectFirst()
+    }
 
     func moveSelection(by delta: Int) {
         let items = visibleItems

--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -102,6 +102,11 @@ struct BarView: View {
         .fixedSize()
     }
 
+    /// Identifies the padded scroll content, so a presentation reset can land
+    /// on the strip's natural resting offset - anchoring the first card's
+    /// leading edge instead would scroll the horizontal inset out of view.
+    private static let stripStartID = "stripStart"
+
     private var strip: some View {
         ScrollViewReader { proxy in
             ScrollView(.horizontal, showsIndicators: false) {
@@ -120,6 +125,14 @@ struct BarView: View {
                 .padding(.top, 16)
                 .padding(.bottom, 26)
                 .animation(.spring(response: 0.34, dampingFraction: 0.8), value: store.visibleItems.count)
+                .id(Self.stripStartID)
+            }
+            .onChange(of: store.barPresentationToken) { _, _ in
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    proxy.scrollTo(Self.stripStartID, anchor: .leading)
+                }
             }
             .onChange(of: store.selectedID) { _, id in
                 guard let id else { return }


### PR DESCRIPTION
Lands the goal of #18 with the trigger reworked per the Aug 11 review:

- `barPresentationToken` on the store, bumped by `showBar()` via `prepareForBarPresentation()`, fires `onChange` on every presentation — including the common trackpad-scroll case where the selection never changes and #18's `onChange(of: selectedID)` trigger stayed silent.
- No state is left behind to hijack a later selection change (the review's second concern with the consumable-flag design).
- The reset scrolls to the padded content container, not the first card's leading edge, so the 49 pt strip inset stays visible (the review's `anchor: .leading` concern).
- Runs with animations disabled, so reopening restores the position instantly.

Credit to @alvst — reworked from #18.

— automated maintainer pass on behalf of @momenbasel

Made with [Cursor](https://cursor.com)