### PR TITLE
Delete the selected clip with a deliberate Backspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It is a faithful, native reimplementation of the Paste experience - built in **S
 - **Pinboards** - save clips you reuse into named, color-tagged collections that never expire.
 - **iCloud sync** - optionally keep your history and pinboards in sync across your Macs via iCloud Drive.
 - **Instant search** - start typing to filter your whole history.
-- **Keyboard-first** - arrow keys to move, `return` to paste, `⌘1`–`⌘9` to quick-paste, `⌘⌫` to delete, `esc` to close.
+- **Keyboard-first** - arrow keys to move, `return` to paste, `⌘1`–`⌘9` to quick-paste, `⌫` or `⌘⌫` to delete, `esc` to close.
 - **Paste directly** - drops the clip into the app you were using, no manual `⌘V` needed.
 - **Privacy-aware** - ignores clips marked concealed by password managers; history stored with `0600` permissions.
 - **Menu-bar app** - runs quietly as a menu-bar item, optional launch at login.
@@ -78,7 +78,7 @@ The build is signed with a Developer ID and notarized by Apple, so it opens with
 | `←` `→` `↑` `↓` | Move selection |
 | `return` | Paste selected clip |
 | `⌘1`–`⌘9` | Quick-paste the Nth clip |
-| `⌘⌫` | Delete selected clip |
+| `⌫` (search empty) or `⌘⌫` | Delete selected clip |
 | type anything | Search |
 | `esc` | Clear search, then close |
 

--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -20,6 +20,12 @@ final class AppController: NSObject, NSApplicationDelegate {
 
     var suppressAutoHide = false
 
+    /// When the search query last became empty via the keyboard. A bare
+    /// Backspace deletes the selected clip, and the keystroke that clears the
+    /// query must stay unambiguously separate from the keystroke that deletes.
+    private var searchClearedAt: Date = .distantPast
+    private static let deleteAfterSearchClearCooldown: TimeInterval = 0.6
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
 
@@ -344,8 +350,10 @@ final class AppController: NSObject, NSApplicationDelegate {
 
         switch code {
         case kVK_Escape:
-            if !store.searchText.isEmpty { store.searchText = ""; store.selectFirst() }
-            else { hideBar() }
+            if !store.searchText.isEmpty {
+                store.searchText = ""; store.selectFirst()
+                searchClearedAt = Date()
+            } else { hideBar() }
             return nil
         case kVK_Return, kVK_ANSI_KeypadEnter:
             pasteSelected(); return nil
@@ -356,7 +364,21 @@ final class AppController: NSObject, NSApplicationDelegate {
         case kVK_Delete:
             if cmd, let sel = store.selectedItem { store.delete(sel); return nil }
             if !store.searchText.isEmpty {
-                store.searchText.removeLast(); store.selectFirst(); return nil
+                store.searchText.removeLast(); store.selectFirst()
+                if store.searchText.isEmpty { searchClearedAt = Date() }
+                return nil
+            }
+            // A bare Backspace deletes the selected clip, but only as a
+            // deliberate, separate keypress. Auto-repeat is ignored - a held
+            // Backspace that just finished clearing a query must not start
+            // deleting clips at the key-repeat rate - and a short cooldown
+            // after the search empties separates "clear the query" from
+            // "delete a clip". There is no undo, and deletions replicate to
+            // other devices when sync is on.
+            if !event.isARepeat,
+               Date().timeIntervalSince(searchClearedAt) > Self.deleteAfterSearchClearCooldown,
+               let sel = store.selectedItem {
+                store.delete(sel)
             }
             return nil
         case kVK_ForwardDelete:

--- a/Sources/Pesty/Store/ClipboardStore.swift
+++ b/Sources/Pesty/Store/ClipboardStore.swift
@@ -130,6 +130,9 @@ final class ClipboardStore {
     /// old cross-container removal deleted entries under two file names but
     /// cleaned up only one of them.
     func delete(_ item: ClipItem) {
+        // Captured before removal so repeated deletes walk down the list
+        // instead of snapping back to the newest clip every time.
+        let deletedIndex = visibleItems.firstIndex(where: { $0.id == item.id })
         let removed: [ClipItem]
         switch source {
         case .history:
@@ -141,7 +144,14 @@ final class ClipboardStore {
             pinboards[boardIndex].items.removeAll { $0.id == item.id }
         }
         for entry in removed { deleteImageFile(entry) }
-        if selectedID == item.id { selectFirst() }
+        if selectedID == item.id {
+            let items = visibleItems
+            if let index = deletedIndex, !items.isEmpty {
+                selectedID = items[min(index, items.count - 1)].id
+            } else {
+                selectFirst()
+            }
+        }
         scheduleSave()
     }
 


### PR DESCRIPTION
Lands #19's feature with the guards the Aug 11 review required:

- `event.isARepeat` is ignored on the delete branch — the blocking issue where a held Backspace that just cleared a query would start deleting clips at the key-repeat rate.
- A 0.6 s cooldown after the search empties (via Backspace or Escape) keeps "clear the query" and "delete a clip" as unambiguous separate intents.
- Deletion now selects the removed card's neighbor (`min(index, count - 1)`) instead of snapping to the newest clip, improving ⌘⌫ / ⌦ as well.
- Pinboard safety was already handled by the scoped delete from #67.
- README's two delete-binding mentions updated.

Credit to @alvst — reworked from #19.

— automated maintainer pass on behalf of @momenbasel

Made with [Cursor](https://cursor.com)