### PR TITLE
Add count and time based history retention

### DIFF
--- a/Sources/Pesty/Settings/Settings.swift
+++ b/Sources/Pesty/Settings/Settings.swift
@@ -45,6 +45,20 @@ enum ShortcutModifier: CaseIterable, Identifiable {
     }
 }
 
+enum HistoryRetentionMode: String, CaseIterable, Identifiable {
+    case itemCount
+    case timeInterval
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .itemCount: return "Number of clips"
+        case .timeInterval: return "Age of clips"
+        }
+    }
+}
+
 @Observable
 @MainActor
 final class Settings {
@@ -55,6 +69,8 @@ final class Settings {
 
     enum Keys {
         static let historyLimit = "historyLimit"
+        static let historyRetentionMode = "historyRetentionMode"
+        static let historyRetentionDays = "historyRetentionDays"
         static let hotkeyKeyCode = "hotkeyKeyCode"
         static let hotkeyModifiers = "hotkeyModifiers"
         static let quickPasteModifier = "quickPasteModifier"
@@ -77,7 +93,21 @@ final class Settings {
             guard isLoaded else { return }
             if historyLimit < 20 { historyLimit = 20; return }
             d.set(historyLimit, forKey: Keys.historyLimit)
-            ClipboardStore.shared.applyHistoryLimit()
+        }
+    }
+
+    var historyRetentionMode: HistoryRetentionMode {
+        didSet {
+            guard isLoaded else { return }
+            d.set(historyRetentionMode.rawValue, forKey: Keys.historyRetentionMode)
+        }
+    }
+
+    var historyRetentionDays: Int {
+        didSet {
+            guard isLoaded else { return }
+            if historyRetentionDays < 1 { historyRetentionDays = 1; return }
+            d.set(historyRetentionDays, forKey: Keys.historyRetentionDays)
         }
     }
 
@@ -167,6 +197,8 @@ final class Settings {
     private init() {
         d.register(defaults: [
             Keys.historyLimit: 500,
+            Keys.historyRetentionMode: HistoryRetentionMode.itemCount.rawValue,
+            Keys.historyRetentionDays: 30,
             Keys.hotkeyKeyCode: kVK_ANSI_V,
             Keys.hotkeyModifiers: cmdKey | shiftKey,
             Keys.quickPasteModifier: cmdKey,
@@ -184,6 +216,9 @@ final class Settings {
             Keys.cloudKitSync: true
         ])
         historyLimit = d.integer(forKey: Keys.historyLimit)
+        historyRetentionMode = HistoryRetentionMode(rawValue: d.string(forKey: Keys.historyRetentionMode) ?? "")
+            ?? .itemCount
+        historyRetentionDays = max(1, d.integer(forKey: Keys.historyRetentionDays))
         hotkeyKeyCode = d.integer(forKey: Keys.hotkeyKeyCode)
         hotkeyModifiers = d.integer(forKey: Keys.hotkeyModifiers)
         quickPasteModifier = d.integer(forKey: Keys.quickPasteModifier)

--- a/Sources/Pesty/Settings/SettingsView.swift
+++ b/Sources/Pesty/Settings/SettingsView.swift
@@ -108,10 +108,9 @@ private struct GeneralSettings: View {
         Form {
             Section("Activation") {
                 LabeledContent("Show Pesty") { HotkeyRecorderView() }
-                Stepper(value: $settings.historyLimit, in: 50...5000, step: 50) {
-                    LabeledContent("History limit", value: "\(settings.historyLimit) items")
-                }
             }
+
+            HistoryRetentionSettings()
 
             Section("Quick Paste") {
                 LabeledContent("Paste items 1–9") {
@@ -233,6 +232,86 @@ private struct GeneralSettings: View {
         .labelsHidden()
         .pickerStyle(.menu)
         .frame(minWidth: 118)
+    }
+}
+
+private struct HistoryRetentionSettings: View {
+    private var settings = Settings.shared
+    @State private var draftMode = Settings.shared.historyRetentionMode
+    @State private var draftLimit = Settings.shared.historyLimit
+    @State private var draftDays = Settings.shared.historyRetentionDays
+    @State private var pendingRemovalCount = 0
+    @State private var confirmingChange = false
+
+    private static let dayChoices: [(days: Int, label: String)] = [
+        (1, "1 Day"), (7, "1 Week"), (14, "2 Weeks"), (30, "1 Month"),
+        (90, "3 Months"), (180, "6 Months"), (365, "1 Year")
+    ]
+
+    var body: some View {
+        Section("History") {
+            Picker("Limit history by", selection: $draftMode) {
+                ForEach(HistoryRetentionMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            if draftMode == .itemCount {
+                Stepper(value: $draftLimit, in: 50...5000, step: 50) {
+                    LabeledContent("Keep at most", value: "\(draftLimit) clips")
+                }
+            } else {
+                Picker("Remove clips older than", selection: $draftDays) {
+                    ForEach(Self.dayChoices, id: \.days) { choice in
+                        Text(choice.label).tag(choice.days)
+                    }
+                }
+            }
+            Text(footnote)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .onChange(of: draftMode) { evaluateDraft() }
+        .onChange(of: draftLimit) { evaluateDraft() }
+        .onChange(of: draftDays) { evaluateDraft() }
+        .alert("Remove \(pendingRemovalCount) Clips?", isPresented: $confirmingChange) {
+            Button("Remove \(pendingRemovalCount) Clips", role: .destructive) { commit() }
+            Button("Cancel", role: .cancel) { revert() }
+        } message: {
+            Text("This setting removes \(pendingRemovalCount) clips from history on this Mac now, and keeps pruning automatically. Pinboards are not affected, and there is no undo.")
+        }
+    }
+
+    private var footnote: String {
+        #if MAS
+        "Pruning tidies this Mac only — synced copies stay on your other devices. Pinned clips are never removed."
+        #else
+        "Pruning applies to this Mac's history. Pinned clips are never removed."
+        #endif
+    }
+
+    private func evaluateDraft() {
+        let count = ClipboardStore.shared.retentionRemovalCount(
+            mode: draftMode, limit: draftLimit, days: draftDays)
+        if count > 0 {
+            pendingRemovalCount = count
+            confirmingChange = true
+        } else {
+            commit()
+        }
+    }
+
+    private func commit() {
+        settings.historyRetentionMode = draftMode
+        settings.historyLimit = draftLimit
+        settings.historyRetentionDays = draftDays
+        ClipboardStore.shared.applyRetentionPolicy()
+    }
+
+    private func revert() {
+        draftMode = settings.historyRetentionMode
+        draftLimit = settings.historyLimit
+        draftDays = settings.historyRetentionDays
     }
 }
 

--- a/Sources/Pesty/Store/ClipboardStore.swift
+++ b/Sources/Pesty/Store/ClipboardStore.swift
@@ -113,13 +113,63 @@ final class ClipboardStore {
         scheduleSave()
     }
 
-    func applyHistoryLimit() { trimHistory(); scheduleSave() }
+    func applyRetentionPolicy() { trimHistory(); scheduleSave() }
+
+    func retentionRemovalCount(mode: HistoryRetentionMode, limit: Int, days: Int) -> Int {
+        switch mode {
+        case .itemCount:
+            return max(0, history.count - max(20, limit))
+        case .timeInterval:
+            let cutoff = Self.retentionCutoff(daysAgo: days)
+            let byAge = history.filter { $0.createdAt < cutoff }.count
+            return byAge + max(0, (history.count - byAge) - Self.timeRetentionSafetyCap)
+        }
+    }
+
+    private static let timeRetentionSafetyCap = 5000
+
+    private static func retentionCutoff(daysAgo days: Int) -> Date {
+        Date().addingTimeInterval(-TimeInterval(max(1, days)) * 86_400)
+    }
+
+    private(set) var retentionPrunedRecordNames: Set<String> = []
+
+    func isRetentionPruned(_ recordName: String) -> Bool {
+        retentionPrunedRecordNames.contains(recordName)
+    }
 
     private func trimHistory() {
-        guard history.count > historyLimit else { return }
-        let removed = Array(history[historyLimit...])
-        history.removeLast(history.count - historyLimit)
+        var removed: [ClipItem] = []
+        switch Settings.shared.historyRetentionMode {
+        case .itemCount:
+            if history.count > historyLimit {
+                removed = Array(history[historyLimit...])
+                history.removeLast(history.count - historyLimit)
+            }
+        case .timeInterval:
+            let cutoff = Self.retentionCutoff(daysAgo: Settings.shared.historyRetentionDays)
+            let old = history.filter { $0.createdAt < cutoff }
+            if !old.isEmpty {
+                removed += old
+                history.removeAll { $0.createdAt < cutoff }
+            }
+            if history.count > Self.timeRetentionSafetyCap {
+                removed += Array(history[Self.timeRetentionSafetyCap...])
+                history.removeLast(history.count - Self.timeRetentionSafetyCap)
+            }
+        }
+        guard !removed.isEmpty else { return }
         for item in removed { deleteImageFile(item) }
+        markRetentionPruned(removed)
+        if let sel = selectedID, removed.contains(where: { $0.id == sel }) { selectFirst() }
+    }
+
+    private func markRetentionPruned(_ items: [ClipItem]) {
+        let names = items.map { $0.id.uuidString }
+        retentionPrunedRecordNames.formUnion(names)
+        #if MAS
+        CloudSyncService.shared.retainRemoteRecords(named: names)
+        #endif
     }
 
     /// Deletes a clip from the collection currently on screen only. A Pinboard
@@ -220,6 +270,7 @@ final class ClipboardStore {
     func selectFirst() { selectedID = visibleItems.first?.id }
 
     func prepareForBarPresentation() {
+        applyRetentionPolicy()
         barPresentationToken &+= 1
         selectFirst()
     }
@@ -383,6 +434,7 @@ final class ClipboardStore {
             deleteImageFile(dup)
         }
         insertSortedByDate(item, into: &history)
+        retentionPrunedRecordNames.remove(item.id.uuidString)
         // Same-id replace: drop the old image file unless something still uses it.
         for old in replaced { deleteImageFile(old) }
     }
@@ -410,6 +462,7 @@ final class ClipboardStore {
             deleteImageFile(dup)
         }
         insertSortedByDate(item, into: &pinboards[i].items)
+        retentionPrunedRecordNames.remove(item.id.uuidString)
         // Same-id replace: drop the old image file unless something still uses it.
         for old in replaced { deleteImageFile(old) }
     }
@@ -467,7 +520,8 @@ final class ClipboardStore {
         var seen = Set<String>()
         var merged: [ClipItem] = []
         for it in combined where seen.insert(contentKey(it)).inserted { merged.append(it) }
-        history = Array(merged.prefix(historyLimit))
+        history = merged
+        trimHistory()
 
         var byID: [UUID: Pinboard] = Dictionary(uniqueKeysWithValues: pinboards.map { ($0.id, $0) })
         for b in snap.pinboards {

--- a/Sources/Pesty/Sync/CloudSyncService.swift
+++ b/Sources/Pesty/Sync/CloudSyncService.swift
@@ -121,6 +121,14 @@ final class CloudSyncService {
         let isPinboard: Bool
     }
 
+    func retainRemoteRecords(named names: [String]) {
+        guard !names.isEmpty else { return }
+        if engine == nil { shadow = loadShadow() }
+        var changed = false
+        for name in names where shadow.removeValue(forKey: name) != nil { changed = true }
+        if changed { saveShadow() }
+    }
+
     private func diffAndEnqueue() {
         guard let engine, !isApplyingRemote else { return }
         let desired = desiredRecords()
@@ -130,6 +138,10 @@ final class CloudSyncService {
             shadow[name] = rec.fingerprint
         }
         for name in Array(shadow.keys) where desired[name] == nil {
+            if store.isRetentionPruned(name) {
+                shadow.removeValue(forKey: name)
+                continue
+            }
             pending.append(.deleteRecord(recordID(name)))
             shadow.removeValue(forKey: name)
             removeSystemFields(name)
@@ -228,6 +240,8 @@ final class CloudSyncService {
             let name = id.uuidString
             if let rec = desired[name] {
                 shadow[name] = rec.fingerprint
+            } else if store.isRetentionPruned(name) {
+                shadow.removeValue(forKey: name)
             } else {
                 shadow.removeValue(forKey: name)
                 removeSystemFields(name)


### PR DESCRIPTION
Supersedes #21, reimplemented from current `main` with the blockers from that review addressed. Original feature by @alvst, credited via `Co-authored-by`.

## What changed vs #21

**Compile safety.** `trimHistory()` is kept as the single trimming API and now understands both retention modes; `applyRemote(clips:)` continues to call it, so both build variants compile.

**Retention pruning is local-only and can no longer wipe synced history.** This was the core blocker: `CloudSyncService.diffAndEnqueue` treats "in shadow but no longer desired" as a record deletion, and `reconcileShadow` enqueues `deleteRecord` for fetched clips that are not desired locally — so a Mac with short retention (or a Mac that was off for a week and fetched everything) would have deleted old clips from the account. Now:

- `trimHistory()` marks every pruned record name and synchronously calls `CloudSyncService.retainRemoteRecords(named:)`, which removes those names from the shadow map and persists it immediately. With no shadow entry and no desired record, the next diff emits nothing — the cloud record survives.
- `diffAndEnqueue` and `reconcileShadow` both additionally skip retention-pruned names as a belt-and-braces guard, so a fetched old clip that is immediately age-trimmed is not reconciled into a `deleteRecord`.
- The shadow removal is persisted at prune time, so a crash or quit between pruning and the next diff cannot resurrect a delete on relaunch.
- If a pruned record later returns from the server (edited on another device), its pruned marker is cleared so a future explicit delete replicates normally.

Explicit user deletions (`delete`, Clear History, pinboard removal) still replicate exactly as before.

**Destructive UX fixed.**
- No slider. Count mode keeps the stepper; age mode is a fixed-choice picker (1 day … 1 year), so there are no intermediate detents that delete as you drag.
- Changes are drafted in the Settings UI and only committed after a confirmation alert that names the exact number of clips that will be removed ("Remove 137 Clips?"); Cancel reverts the control. Enlarging the limit (removal count 0) commits silently.
- No "Forever" option. Age mode also keeps a hard 5000-item safety cap, so history stays bounded in every configuration (`mergeExternal` now routes through the same trim).
- Age pruning also runs on bar presentation, so time-based retention converges on idle Macs without waiting for a new copy.

## Verification

- `swift build` — passes
- `swift build -Xswiftc -DMAS` — passes
- Reviewed every path into `trimHistory` (capture, remote apply, presentation, settings commit, external merge): all route through the same prune-marking, none feed `diffAndEnqueue` deletions.

Made with [Cursor](https://cursor.com)