### PR TITLE
Add a standalone SwiftPM smoke test

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,11 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-parse-as-library"])
             ]
+        ),
+        .testTarget(
+            name: "PestyTests",
+            dependencies: ["Pesty"],
+            path: "Tests/PestyTests"
         )
     ],
     swiftLanguageModes: [.v5]

--- a/Tests/PestyTests/ClipItemTests.swift
+++ b/Tests/PestyTests/ClipItemTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import Pesty
+
+final class ClipItemTests: XCTestCase {
+    func testCodableRoundTripPreservesClipMetadata() throws {
+        let original = ClipItem(
+            id: UUID(uuidString: "61F39299-3C8E-45AE-90BA-C53889BF9304")!,
+            type: .link,
+            text: "https://example.com/path",
+            sourceBundleID: "com.apple.Safari",
+            sourceAppName: "Safari",
+            customTitle: "Example",
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ClipItem.self, from: encoded)
+
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.displayTitle, "Example")
+    }
+}


### PR DESCRIPTION
Adds a small XCTest (`ClipItemTests.testCodableRoundTripPreservesClipMetadata`) that round-trips a `ClipItem` through `JSONEncoder`/`JSONDecoder` and asserts every field survives, plus the `Package.swift` wiring needed to run it as a standalone SwiftPM test target.

No visual delta — this is test-only, nothing in the strip changes.

`swift build` is clean with no warnings.

---

**Note:** I'd like to keep this PR separate and hold off on merge until it's complete — I'm working through a stack of related changes one focused PR at a time (this is the first/base one), so marking as draft for now.