### PR TITLE
Copy the selected clip with Command-C

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -8,6 +8,7 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     let store = ClipboardStore.shared
     let monitor = ClipboardMonitor()
+    private let copyToast = CopyToastController()
 
     private var barController: BarWindowController?
     private var statusItem: NSStatusItem?
@@ -324,9 +325,19 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func copyItem(_ item: ClipItem) {
+        let previousChange = NSPasteboard.general.changeCount
         let change = PasteService.copy(item)
         monitor.suppressUntilChangeCount = change
+        if change != previousChange {
+            store.promoteCopiedItem(item)
+        }
         hideBar()
+        copyToast.show()
+    }
+
+    func copySelected() {
+        guard let item = store.selectedItem else { return }
+        copyItem(item)
     }
 
     var pasteMenuTitle: String {
@@ -550,6 +561,8 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
         case kVK_ForwardDelete:
             deleteEffectiveSelection()
             return nil
+        case kVK_ANSI_C:
+            if cmd { copySelected(); return nil }
         default:
             break
         }

--- a/Sources/Pesty/Store/ClipboardStore.swift
+++ b/Sources/Pesty/Store/ClipboardStore.swift
@@ -123,6 +123,16 @@ final class ClipboardStore {
         scheduleSave()
     }
 
+    /// A Copy from the Paste Bar is an intentional use of an existing clip.
+    /// Promote it explicitly because the clipboard monitor correctly ignores
+    /// Pesty's own pasteboard writes, so a plain re-copy would otherwise leave
+    /// the clip sitting wherever it already was in history.
+    func promoteCopiedItem(_ item: ClipItem, at date: Date = .now) {
+        var copied = item
+        copied.createdAt = date
+        addCaptured(copied)
+    }
+
     func applyRetentionPolicy() { trimHistory(); scheduleSave() }
 
     func retentionRemovalCount(mode: HistoryRetentionMode, limit: Int, days: Int) -> Int {

--- a/Sources/Pesty/UI/CopyToastController.swift
+++ b/Sources/Pesty/UI/CopyToastController.swift
@@ -1,0 +1,74 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class CopyToastController {
+    private let panel: NSPanel
+    private var dismissWorkItem: DispatchWorkItem?
+
+    init() {
+        panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 236, height: 48),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false)
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.level = .floating
+        panel.ignoresMouseEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        panel.contentView = NSHostingView(rootView: CopyToastView())
+    }
+
+    func show() {
+        dismissWorkItem?.cancel()
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        guard let screen else { return }
+
+        let frame = screen.visibleFrame
+        panel.setFrameOrigin(NSPoint(x: frame.midX - panel.frame.width / 2, y: frame.minY + 34))
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.16
+            panel.animator().alphaValue = 1
+        }
+
+        let dismiss = DispatchWorkItem { [weak self] in self?.dismiss() }
+        dismissWorkItem = dismiss
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.25, execute: dismiss)
+    }
+
+    private func dismiss() {
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.18
+            panel.animator().alphaValue = 0
+        }, completionHandler: { [weak panel] in
+            panel?.orderOut(nil)
+        })
+    }
+}
+
+private struct CopyToastView: View {
+    var body: some View {
+        HStack(spacing: 9) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(Theme.selection)
+            Text("Copied to Clipboard")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.regularMaterial, in: Capsule(style: .continuous))
+        .overlay {
+            Capsule(style: .continuous)
+                .strokeBorder(.white.opacity(0.28))
+        }
+    }
+}


### PR DESCRIPTION
⌘C in the bar copies the selected clip to the pasteboard, the same path the context menu's Copy already uses. Every successful copy now shows a brief "Copied to Clipboard" toast, so a copy that doesn't paste anywhere still gives feedback.

## What changed

- ⌘C copies the selected clip; the context menu's Copy action and ⌘C both route through `copyItem`.
- A "Copied to Clipboard" toast appears after every successful copy and fades on its own.
- A copied clip is promoted to the front of history.

## Screenshots


**Before:**
![00-baseline screenshots bar.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/00-baseline/screenshots/bar.png)

**After:**
![01-cmd-c-copy screenshots after.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/01-cmd-c-copy/screenshots/after.png)

## Notes for review

- **The promote-to-front is deliberate, not a side effect.** Copying a clip back out of history is a re-use of it, and the monitor correctly ignores Pesty's own pasteboard writes, so without this the clip you just reached for stays buried where it was. It's the same ordering rule a fresh copy from any other app already gets.
- Merge-order note: `alvie/pr-16-paste-reliability` adds a byte-identical `ClipboardStore.promoteCopiedItem(_:at:)`. Git places them in different regions of the file, so it will **not** conflict — it will produce two identical methods and a redeclaration error. Whichever of the two merges second, delete the duplicate.
- Out of scope: no toast for pastes, and no setting to turn the toast off.

---

**This feature should be bundled into v2.**

Part of #80.
