### PR TITLE
Switch bar sections with Command-Left and Command-Right

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -524,9 +524,15 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
             return nil
         case kVK_Return, kVK_ANSI_KeypadEnter:
             pasteSelected(); return nil
-        case kVK_LeftArrow, kVK_UpArrow:
+        case kVK_LeftArrow:
+            if cmd { moveBarSection(by: -1) } else { store.moveSelection(by: -1) }
+            return nil
+        case kVK_RightArrow:
+            if cmd { moveBarSection(by: 1) } else { store.moveSelection(by: 1) }
+            return nil
+        case kVK_UpArrow:
             store.moveSelection(by: -1); return nil
-        case kVK_RightArrow, kVK_DownArrow:
+        case kVK_DownArrow:
             store.moveSelection(by: 1); return nil
         case kVK_Delete:
             if cmd { deleteEffectiveSelection(); return nil }
@@ -563,6 +569,19 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
             return nil
         }
         return event
+    }
+
+    /// Cycles the same sources, in the same order, that the tab bar presents.
+    /// The plus button is intentionally excluded: it creates a new pinboard
+    /// rather than representing a navigable section.
+    private func moveBarSection(by delta: Int) {
+        let sources: [BarSource] = [.history] + store.pinboards.map { .pinboard($0.id) }
+        guard !sources.isEmpty else { return }
+
+        let currentIndex = sources.firstIndex(of: store.source) ?? 0
+        let nextIndex = (currentIndex + delta % sources.count + sources.count) % sources.count
+        store.source = sources[nextIndex]
+        store.selectFirst()
     }
 
     private static func quickPasteDigit(for keyCode: Int) -> Int? {


### PR DESCRIPTION
⌘← and ⌘→ move between Clipboard and the Pinboard tabs without reaching for the mouse. Plain arrow keys keep moving the card selection, so the two navigations don't fight.

## What changed

- ⌘← / ⌘→ cycle Clipboard and each Pinboard in the order the tab bar already presents them.
- Card navigation is untouched: unmodified arrows still move the selection within the current section.

## Screenshots

No visual change — this is a keyboard-only addition. It adds no chrome; ⌘←/⌘→ perform the same section switch a click on the tab row already does, so the resulting UI is identical to what a click produces today.

For context, a Pinboard reached by the new shortcut — identical to reaching it by clicking the tab:
![02-section-switch screenshots after.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/02-section-switch/screenshots/after.png)

## Notes for review

- No dependencies; merges in any order.
- Checked against upstream's existing bindings: the new cases are ⌘-guarded and sit ahead of the printable-character search fall-through, so no existing shortcut changes meaning.
- Out of scope: no wrap-around preference and no menu items for the same action.

---

**This feature should be bundled into v2.**

Part of #80.
