### PR TITLE
Add icons to the bar's overflow menu

### DIFF
--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -106,11 +106,19 @@ struct BarView: View {
 
     private var moreMenu: some View {
         Menu {
-            Button("Settings…") { AppController.shared.showSettings() }
-            Button("Clear History") { store.clearHistory() }
+            Button { AppController.shared.showSettings() } label: {
+                Label("Settings…", systemImage: "gearshape")
+            }
+            Button { store.clearHistory() } label: {
+                Label("Clear History", systemImage: "trash")
+            }
             Divider()
-            Button("About Pesty") { AppController.shared.showAbout() }
-            Button("Quit Pesty") { NSApp.terminate(nil) }
+            Button { AppController.shared.showAbout() } label: {
+                Label("About Pesty", systemImage: "info.circle")
+            }
+            Button { NSApp.terminate(nil) } label: {
+                Label("Quit Pesty", systemImage: "power")
+            }
         } label: {
             Image(systemName: "ellipsis")
                 .font(.system(size: 15, weight: .semibold))


### PR DESCRIPTION
Settings, Clear History, About, and Quit were the only menu items in the app with no icon. This adds SF Symbols to match the convention every other menu already follows.

## What changed

- Settings, Clear History, About, and Quit in the bar's ⋯ menu get SF Symbol icons.
- No wording, ordering, or behavior changes.

## Screenshots


**Before:**
![00-baseline screenshots overflow-menu.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/00-baseline/screenshots/overflow-menu.png)

**After:**
![03-menu-icons screenshots after.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/03-menu-icons/screenshots/after.png)

## Notes for review

- No dependencies; merges in any order.
- Symbol choices follow the ones already used elsewhere in the app for the same actions — happy to swap any that read wrong.

---

**This feature should be bundled into v2.**

Part of #80.
