### PR TITLE
Fix the bulk-delete button collapsing to icon-only

### DIFF
--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -100,6 +100,7 @@ struct BarView: View {
         }
         .buttonStyle(.bordered)
         .controlSize(.small)
+        .fixedSize()
         .help("Delete \(count) selected clips (⌘⌫)")
         .accessibilityLabel("Delete \(count) selected clips")
     }


### PR DESCRIPTION
The "Delete N" button in the top bar was losing its label. A missing `.fixedSize()` let the tight top-bar `HStack` compress it down to just the icon, so the count — the part that tells you how much you're about to destroy — disappeared.

## What changed

- The bulk-delete button gets `.fixedSize()`, so it keeps its "Delete N" text instead of being squeezed to its icon.

## Screenshots


**Before:**
![00-baseline screenshots bar.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/00-baseline/screenshots/bar.png)

**After:**
![05-bulk-delete-label screenshots after.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/05-bulk-delete-label/screenshots/after.png)

## Notes for review

- This is a pre-existing bug in already-merged upstream code (multi-select bulk deletion, #77), not a regression from anything in this batch.
- One line, no dependencies.

---

**This feature should be bundled into v2.**

Part of #80.
