### PR TITLE
Add a 5-minute Undo window for deleted clips

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -405,35 +405,42 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
-    func deleteEffectiveSelection() {
+    /// `permanently` bypasses the Undo ledger for this deletion regardless of
+    /// the Settings toggle — set when the user held Option.
+    func deleteEffectiveSelection(permanently: Bool = false) {
         let selection = store.effectiveSelectionIDs
         let targets = store.visibleItems.filter { selection.contains($0.id) }
         guard !targets.isEmpty else { return }
         if targets.count == 1 {
-            store.delete(targets[0])
+            store.delete(targets[0], permanently: permanently)
             return
         }
         suppressAutoHide = true
         defer { suppressAutoHide = false }
         let alert = NSAlert()
         alert.messageText = "Delete \(targets.count) Clips?"
+        let undoesPermanently = permanently || Settings.shared.deletePermanently
         #if MAS
-        alert.informativeText = "There is no undo. When iCloud sync is on, these clips are also removed from your other devices."
+        alert.informativeText = undoesPermanently
+            ? "This cannot be undone. When iCloud sync is on, these clips are also removed from your other devices."
+            : "You can undo this with ⌘Z for the next 5 minutes. When iCloud sync is on, these clips are also removed from your other devices."
         #else
-        alert.informativeText = "There is no undo."
+        alert.informativeText = undoesPermanently
+            ? "This cannot be undone."
+            : "You can undo this with ⌘Z for the next 5 minutes."
         #endif
         let confirm = alert.addButton(withTitle: "Delete \(targets.count) Clips")
         confirm.hasDestructiveAction = true
         alert.addButton(withTitle: "Cancel")
         guard alert.runModal() == .alertFirstButtonReturn else { return }
-        store.delete(items: targets)
+        store.delete(items: targets, permanently: permanently)
     }
 
-    func deleteSelection(containing item: ClipItem) {
+    func deleteSelection(containing item: ClipItem, permanently: Bool = false) {
         if store.multiSelectedIDs.contains(item.id) {
-            deleteEffectiveSelection()
+            deleteEffectiveSelection(permanently: permanently)
         } else {
-            store.delete(item)
+            store.delete(item, permanently: permanently)
         }
     }
 
@@ -529,7 +536,7 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
         case kVK_RightArrow, kVK_DownArrow:
             store.moveSelection(by: 1); return nil
         case kVK_Delete:
-            if cmd { deleteEffectiveSelection(); return nil }
+            if cmd { deleteEffectiveSelection(permanently: opt); return nil }
             if !store.searchText.isEmpty {
                 store.searchText.removeLast(); store.selectFirst()
                 if store.searchText.isEmpty { searchClearedAt = Date() }
@@ -540,16 +547,20 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
             // Backspace that just finished clearing a query must not start
             // deleting clips at the key-repeat rate - and a short cooldown
             // after the search empties separates "clear the query" from
-            // "delete a clip". There is no undo, and deletions replicate to
-            // other devices when sync is on.
+            // "delete a clip". Command-Z undoes within five minutes (hold
+            // Option to skip Undo for just this deletion), and deletions
+            // replicate to other devices when sync is on.
             if !event.isARepeat,
                Date().timeIntervalSince(searchClearedAt) > Self.deleteAfterSearchClearCooldown {
-                deleteEffectiveSelection()
+                deleteEffectiveSelection(permanently: opt)
             }
             return nil
         case kVK_ForwardDelete:
-            deleteEffectiveSelection()
+            deleteEffectiveSelection(permanently: opt)
             return nil
+        case kVK_ANSI_Z:
+            if cmd, !flags.contains(.shift), !flags.contains(.option), !flags.contains(.control),
+               store.undoLastDelete() { return nil }
         default:
             break
         }

--- a/Sources/Pesty/Settings/Settings.swift
+++ b/Sources/Pesty/Settings/Settings.swift
@@ -80,6 +80,7 @@ final class Settings {
         static let pasteDirectly = "pasteDirectly"
         static let playSound = "playSound"
         static let ignoreConcealed = "ignoreConcealed"
+        static let deletePermanently = "deletePermanently"
         static let ignoredSourceAppBundleIDs = "ignoredSourceAppBundleIDs"
         static let barHeight = "barHeight"
         static let showMenuBarIcon = "showMenuBarIcon"
@@ -158,6 +159,13 @@ final class Settings {
         didSet { guard isLoaded else { return }; d.set(ignoreConcealed, forKey: Keys.ignoreConcealed) }
     }
 
+    /// Skips the five-minute Undo window entirely: deleted clips are purged
+    /// immediately instead of sitting recoverable (payload and all) in
+    /// store.json until the window closes.
+    var deletePermanently: Bool {
+        didSet { guard isLoaded else { return }; d.set(deletePermanently, forKey: Keys.deletePermanently) }
+    }
+
     /// Applications whose copied content should never be recorded in history.
     /// Store bundle identifiers rather than paths so the choice continues to work
     /// when an app is updated or moved.
@@ -208,6 +216,7 @@ final class Settings {
             Keys.pasteDirectly: true,
             Keys.playSound: false,
             Keys.ignoreConcealed: true,
+            Keys.deletePermanently: false,
             Keys.ignoredSourceAppBundleIDs: [],
             Keys.barHeight: 430.0,
             Keys.showMenuBarIcon: true,
@@ -228,6 +237,7 @@ final class Settings {
         pasteDirectly = d.bool(forKey: Keys.pasteDirectly)
         playSound = d.bool(forKey: Keys.playSound)
         ignoreConcealed = d.bool(forKey: Keys.ignoreConcealed)
+        deletePermanently = d.bool(forKey: Keys.deletePermanently)
         ignoredSourceAppBundleIDs = (d.stringArray(forKey: Keys.ignoredSourceAppBundleIDs) ?? [])
             .filter { !$0.isEmpty }
         barHeight = d.double(forKey: Keys.barHeight)

--- a/Sources/Pesty/Settings/SettingsView.swift
+++ b/Sources/Pesty/Settings/SettingsView.swift
@@ -200,6 +200,10 @@ private struct GeneralSettings: View {
             #endif
 
             Section("Data") {
+                Toggle("Delete permanently", isOn: $settings.deletePermanently)
+                Text("Skips the five-minute Undo window — deleted clips are removed immediately and can't be recovered. Hold Option while deleting to bypass Undo for just one deletion, regardless of this setting.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 Button("Clear Clipboard History", role: .destructive) {
                     ClipboardStore.shared.clearHistory()
                 }

--- a/Sources/Pesty/Store/ClipDeletionLedger.swift
+++ b/Sources/Pesty/Store/ClipDeletionLedger.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+/// The exact location of a clip before it was removed from clipboard history.
+/// Keeping the index makes Undo restore the strip instead of moving the clip to
+/// an arbitrary position.
+struct HistoryClipPlacement: Codable {
+    var index: Int
+    var item: ClipItem
+    var predecessorID: UUID? = nil
+    var successorID: UUID? = nil
+}
+
+/// A pinboard can hold its own image-file copy of a clip, so the complete item
+/// is retained rather than just its ID.
+struct PinboardClipPlacement: Codable {
+    var pinboardID: UUID
+    var index: Int
+    var item: ClipItem
+    var predecessorID: UUID? = nil
+    var successorID: UUID? = nil
+}
+
+/// The comparatively large, short-lived part of a deletion record. It is
+/// discarded when the Undo window closes; the small sync marker remains.
+struct ClipDeletionPayload: Codable {
+    var history: [HistoryClipPlacement]
+    var pinboards: [PinboardClipPlacement]
+
+    var allItems: [ClipItem] {
+        history.map(\.item) + pinboards.map(\.item)
+    }
+}
+
+struct ClipItemRestoration {
+    var deletionPayload: ClipDeletionPayload?
+}
+
+/// A durable last-writer-wins marker for one clip ID. Restored records remain
+/// in the ledger so an older tombstone arriving from a synced snapshot cannot
+/// delete the item again. Finalized deletion records likewise prevent stale
+/// live items from being resurrected after the Undo payload has been discarded.
+struct ClipDeletionRecord: Identifiable, Codable {
+    let id: UUID
+    let operationID: UUID
+    var deletedAt: Date
+    var restoredAt: Date?
+    var finalizedAt: Date?
+    var payload: ClipDeletionPayload?
+
+    var isDeleted: Bool { restoredAt == nil }
+
+    var presenceChangedAt: Date {
+        restoredAt ?? deletedAt
+    }
+}
+
+struct ClipDeletionLedger: Codable {
+    static let undoWindow: TimeInterval = 5 * 60
+
+    private(set) var records: [ClipDeletionRecord] = []
+
+    var deletedIDs: Set<UUID> {
+        Set(records.lazy.filter(\.isDeleted).map(\.id))
+    }
+
+    mutating func recordDeletion(id: UUID, payload: ClipDeletionPayload, at date: Date) {
+        let previousChange = records
+            .filter { $0.id == id }
+            .map(\.presenceChangedAt)
+            .max()
+        let deletionDate = max(date, previousChange?.addingTimeInterval(0.000_001) ?? date)
+        let record = ClipDeletionRecord(
+            id: id,
+            operationID: UUID(),
+            deletedAt: deletionDate,
+            restoredAt: nil,
+            finalizedAt: nil,
+            payload: payload
+        )
+        if let index = records.firstIndex(where: { $0.id == id }) {
+            records[index] = record
+        } else {
+            records.append(record)
+        }
+    }
+
+    /// A recaptured clip (e.g. re-copied after deletion) publishes a newer
+    /// active marker for the same entity instead of letting the tombstone
+    /// remove it again on the next merge.
+    mutating func restoreItemIfNeeded(_ id: UUID, at date: Date) -> ClipItemRestoration? {
+        guard let index = records.firstIndex(where: { $0.id == id && $0.isDeleted }) else { return nil }
+        let payload = records[index].payload
+        let activeDate = max(
+            date,
+            records[index].presenceChangedAt.addingTimeInterval(0.000_001)
+        )
+        records[index].restoredAt = activeDate
+        records[index].finalizedAt = nil
+        records[index].payload = nil
+        return ClipItemRestoration(deletionPayload: payload)
+    }
+
+    func hasUndoableDeletion(at date: Date) -> Bool {
+        latestUndoableIndex(at: date) != nil
+    }
+
+    func nextExpirationDate(after date: Date) -> Date? {
+        records.lazy
+            .filter { isUndoable($0, at: date) }
+            .map { $0.deletedAt.addingTimeInterval(Self.undoWindow) }
+            .min()
+    }
+
+    /// Restores the newest still-undoable deletion. Older independent deletes
+    /// remain available, giving repeated presses conventional LIFO behavior.
+    mutating func undoMostRecent(at date: Date) -> (id: UUID, payload: ClipDeletionPayload)? {
+        guard let index = latestUndoableIndex(at: date),
+              let payload = records[index].payload else { return nil }
+        let id = records[index].id
+        records[index].restoredAt = max(
+            date,
+            records[index].presenceChangedAt.addingTimeInterval(0.000_001)
+        )
+        records[index].finalizedAt = nil
+        records[index].payload = nil
+        return (id, payload)
+    }
+
+    /// Drops expired Undo payloads but intentionally retains their tombstones.
+    /// The returned payloads identify image files that may now be unlinked.
+    mutating func finalizeExpired(at date: Date) -> [ClipDeletionPayload] {
+        var finalized: [ClipDeletionPayload] = []
+        for index in records.indices {
+            guard records[index].isDeleted,
+                  records[index].finalizedAt == nil,
+                  date >= records[index].deletedAt.addingTimeInterval(Self.undoWindow) else {
+                continue
+            }
+            if let payload = records[index].payload { finalized.append(payload) }
+            records[index].payload = nil
+            records[index].finalizedAt = date
+        }
+        return finalized
+    }
+
+    /// Merges sync metadata independently of the live item arrays. At equal
+    /// timestamps, deletion/finalization wins to avoid accidental resurrection.
+    mutating func merge(_ other: ClipDeletionLedger) {
+        for candidate in other.records {
+            guard let index = records.firstIndex(where: { $0.id == candidate.id }) else {
+                records.append(candidate)
+                continue
+            }
+            if shouldReplace(records[index], with: candidate) {
+                records[index] = candidate
+            }
+        }
+    }
+
+    func retainsImageFile(named name: String) -> Bool {
+        records.contains { record in
+            record.payload?.allItems.contains(where: { $0.imageFileName == name }) == true
+        }
+    }
+
+    private func latestUndoableIndex(at date: Date) -> Int? {
+        records.indices
+            .filter { isUndoable(records[$0], at: date) }
+            .max { records[$0].deletedAt < records[$1].deletedAt }
+    }
+
+    private func isUndoable(_ record: ClipDeletionRecord, at date: Date) -> Bool {
+        record.isDeleted
+            && record.finalizedAt == nil
+            && record.payload != nil
+            && date < record.deletedAt.addingTimeInterval(Self.undoWindow)
+    }
+
+    private func shouldReplace(_ current: ClipDeletionRecord,
+                               with candidate: ClipDeletionRecord) -> Bool {
+        if candidate.presenceChangedAt != current.presenceChangedAt {
+            return candidate.presenceChangedAt > current.presenceChangedAt
+        }
+        if candidate.isDeleted != current.isDeleted {
+            return candidate.isDeleted
+        }
+        if candidate.operationID != current.operationID {
+            return candidate.operationID.uuidString > current.operationID.uuidString
+        }
+        if (candidate.finalizedAt != nil) != (current.finalizedAt != nil) {
+            return candidate.finalizedAt != nil
+        }
+        if let candidateFinalizedAt = candidate.finalizedAt,
+           let currentFinalizedAt = current.finalizedAt,
+           candidateFinalizedAt != currentFinalizedAt {
+            return candidateFinalizedAt > currentFinalizedAt
+        }
+        if (candidate.payload == nil) != (current.payload == nil) {
+            return candidate.payload == nil
+        }
+        return false
+    }
+}

--- a/Sources/Pesty/Store/ClipboardStore.swift
+++ b/Sources/Pesty/Store/ClipboardStore.swift
@@ -17,6 +17,9 @@ final class ClipboardStore {
 
     private(set) var history: [ClipItem] = []
     private(set) var pinboards: [Pinboard] = []
+    private var deletionLedger = ClipDeletionLedger()
+    private(set) var hasUndoableDeletion = false
+    private var undoExpirationWorkItem: DispatchWorkItem?
 
     var source: BarSource = .history {
         didSet { if source != oldValue { clearMultiSelection() } }
@@ -190,11 +193,18 @@ final class ClipboardStore {
     /// Deleting exactly what was removed also closes an image-file leak: the
     /// old cross-container removal deleted entries under two file names but
     /// cleaned up only one of them.
-    func delete(_ item: ClipItem) { delete(items: [item]) }
+    func delete(_ item: ClipItem, at date: Date = .now, permanently: Bool = false) {
+        delete(items: [item], at: date, permanently: permanently)
+    }
 
-    func delete(items: [ClipItem]) {
+    /// `permanently` skips the Undo ledger entirely, so the deleted content
+    /// never sits recoverable in `store.json` even for the five-minute
+    /// window — either because the user turned that off globally in
+    /// Settings, or held Option for this one deletion.
+    func delete(items: [ClipItem], at date: Date = .now, permanently: Bool = false) {
         let ids = Set(items.map(\.id))
         guard !ids.isEmpty else { return }
+        let permanently = permanently || Settings.shared.deletePermanently
         // Captured before removal so repeated deletes walk down the list
         // instead of snapping back to the newest clip every time.
         let deletedIndex = visibleItems.firstIndex(where: { ids.contains($0.id) })
@@ -202,12 +212,50 @@ final class ClipboardStore {
         let removed: [ClipItem]
         switch source {
         case .history:
-            removed = history.filter { ids.contains($0.id) }
+            let placements: [HistoryClipPlacement] = history.enumerated().compactMap { index, existing in
+                guard ids.contains(existing.id) else { return nil }
+                return HistoryClipPlacement(
+                    index: index,
+                    item: existing,
+                    predecessorID: index > 0 ? history[index - 1].id : nil,
+                    successorID: index + 1 < history.count ? history[index + 1].id : nil
+                )
+            }
+            removed = placements.map(\.item)
             history.removeAll { ids.contains($0.id) }
+            if !permanently {
+                for placement in placements {
+                    deletionLedger.recordDeletion(
+                        id: placement.item.id,
+                        payload: ClipDeletionPayload(history: [placement], pinboards: []),
+                        at: date
+                    )
+                }
+            }
         case .pinboard(let boardID):
             guard let boardIndex = pinboards.firstIndex(where: { $0.id == boardID }) else { return }
-            removed = pinboards[boardIndex].items.filter { ids.contains($0.id) }
+            let items = pinboards[boardIndex].items
+            let placements: [PinboardClipPlacement] = items.enumerated().compactMap { index, existing in
+                guard ids.contains(existing.id) else { return nil }
+                return PinboardClipPlacement(
+                    pinboardID: boardID,
+                    index: index,
+                    item: existing,
+                    predecessorID: index > 0 ? items[index - 1].id : nil,
+                    successorID: index + 1 < items.count ? items[index + 1].id : nil
+                )
+            }
+            removed = placements.map(\.item)
             pinboards[boardIndex].items.removeAll { ids.contains($0.id) }
+            if !permanently {
+                for placement in placements {
+                    deletionLedger.recordDeletion(
+                        id: placement.item.id,
+                        payload: ClipDeletionPayload(history: [], pinboards: [placement]),
+                        at: date
+                    )
+                }
+            }
         }
         for entry in removed { deleteImageFile(entry) }
         multiSelectedIDs.subtract(ids)
@@ -222,7 +270,112 @@ final class ClipboardStore {
             selectionAnchorID = selectedID
         }
         reconcileMultiSelection()
+        _ = refreshDeletionState(at: date)
         scheduleSave()
+    }
+
+    /// Restores the newest deletion whose five-minute window is still open.
+    /// A newer active marker remains in the ledger so an older synced snapshot
+    /// cannot immediately remove the clip again. Older independent deletions
+    /// stay available, so repeated Undo presses walk backward in order.
+    @discardableResult
+    func undoLastDelete(at date: Date = .now) -> Bool {
+        let finalizedExpiredDeletion = refreshDeletionState(at: date)
+        guard let deletion = deletionLedger.undoMostRecent(at: date) else {
+            if finalizedExpiredDeletion { saveNow() }
+            return false
+        }
+
+        var restoredSomewhere = history.contains(where: { $0.id == deletion.id })
+            || pinboards.contains { $0.items.contains(where: { $0.id == deletion.id }) }
+        for placement in deletion.payload.history.sorted(by: { $0.index < $1.index }) {
+            guard !history.contains(where: { $0.id == placement.item.id }) else { continue }
+            let index = restorationIndex(
+                originalIndex: placement.index,
+                predecessorID: placement.predecessorID,
+                successorID: placement.successorID,
+                in: history
+            )
+            history.insert(placement.item, at: index)
+            restoredSomewhere = true
+        }
+        for placement in deletion.payload.pinboards {
+            guard let boardIndex = pinboards.firstIndex(where: { $0.id == placement.pinboardID }),
+                  !pinboards[boardIndex].items.contains(where: { $0.id == placement.item.id }) else {
+                continue
+            }
+            let index = restorationIndex(
+                originalIndex: placement.index,
+                predecessorID: placement.predecessorID,
+                successorID: placement.successorID,
+                in: pinboards[boardIndex].items
+            )
+            pinboards[boardIndex].items.insert(placement.item, at: index)
+            restoredSomewhere = true
+        }
+
+        // A clip that existed only in a Pinboard still needs a destination if
+        // that Pinboard was deleted during the Undo window.
+        if !restoredSomewhere, let fallback = deletion.payload.allItems.first {
+            history.insert(fallback, at: 0)
+        }
+
+        // Remove payload-only image copies for destinations that no longer
+        // exist; restored references remain protected by reachability checks.
+        for item in deletion.payload.allItems { deleteImageFile(item) }
+
+        _ = refreshDeletionState(at: date)
+        if visibleItems.contains(where: { $0.id == deletion.id }) {
+            selectedID = deletion.id
+        }
+        scheduleSave()
+        return true
+    }
+
+    private func restorationIndex(originalIndex: Int,
+                                  predecessorID: UUID?,
+                                  successorID: UUID?,
+                                  in items: [ClipItem]) -> Int {
+        if let predecessorID,
+           let index = items.firstIndex(where: { $0.id == predecessorID }) {
+            return index + 1
+        }
+        if let successorID,
+           let index = items.firstIndex(where: { $0.id == successorID }) {
+            return index
+        }
+        return min(max(0, originalIndex), items.count)
+    }
+
+    /// Recomputes observable Undo state from absolute timestamps, so sleep,
+    /// relaunch, and clock changes do not extend the five-minute window.
+    @discardableResult
+    private func refreshDeletionState(at date: Date) -> Bool {
+        let expiredPayloads = deletionLedger.finalizeExpired(at: date)
+        for payload in expiredPayloads {
+            for item in payload.allItems { deleteImageFile(item) }
+        }
+
+        hasUndoableDeletion = deletionLedger.hasUndoableDeletion(at: date)
+        scheduleNextUndoExpiration(after: date)
+        return !expiredPayloads.isEmpty
+    }
+
+    private func scheduleNextUndoExpiration(after date: Date) {
+        undoExpirationWorkItem?.cancel()
+        undoExpirationWorkItem = nil
+        guard let expiration = deletionLedger.nextExpirationDate(after: date) else { return }
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            let changed = self.refreshDeletionState(at: .now)
+            if changed { self.saveNow() }
+        }
+        undoExpirationWorkItem = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + max(0, expiration.timeIntervalSince(date)),
+            execute: work
+        )
     }
 
     func clearHistory() {
@@ -500,6 +653,7 @@ final class ClipboardStore {
         guard let name = item.imageFileName else { return }
         let stillUsed = history.contains { $0.imageFileName == name }
             || pinboards.contains { $0.items.contains { $0.imageFileName == name } }
+            || deletionLedger.retainsImageFile(named: name)
         if stillUsed { return }
         if let url = imageURL(for: item) { try? FileManager.default.removeItem(at: url) }
     }
@@ -507,6 +661,7 @@ final class ClipboardStore {
     private struct Snapshot: Codable {
         var history: [ClipItem]
         var pinboards: [Pinboard]
+        var deletionLedger: ClipDeletionLedger?
     }
 
     private func load() {
@@ -514,7 +669,26 @@ final class ClipboardStore {
               let snap = try? JSONDecoder().decode(Snapshot.self, from: data) else { return }
         history = snap.history
         pinboards = snap.pinboards
+        deletionLedger = snap.deletionLedger ?? ClipDeletionLedger()
+        applyDeletionTombstones()
+        _ = refreshDeletionState(at: .now)
         selectFirst()
+    }
+
+    /// Applies durable presence markers to every location after decoding a
+    /// snapshot. This is deliberately independent of deletion-by-absence: an
+    /// older payload may coexist with its tombstone after a merge conflict.
+    private func applyDeletionTombstones() {
+        let deletedIDs = deletionLedger.deletedIDs
+        guard !deletedIDs.isEmpty else { return }
+        let isDeleted: (ClipItem) -> Bool = { deletedIDs.contains($0.id) }
+        let removed = history.filter(isDeleted)
+            + pinboards.flatMap { $0.items.filter(isDeleted) }
+        history.removeAll(where: isDeleted)
+        for index in pinboards.indices {
+            pinboards[index].items.removeAll(where: isDeleted)
+        }
+        for item in removed { deleteImageFile(item) }
     }
 
     private func scheduleSave() {
@@ -525,7 +699,7 @@ final class ClipboardStore {
     }
 
     func saveNow() {
-        let snap = Snapshot(history: history, pinboards: pinboards)
+        let snap = Snapshot(history: history, pinboards: pinboards, deletionLedger: deletionLedger)
         guard let data = try? JSONEncoder().encode(snap) else { return }
         ignoreWatchUntil = Date().addingTimeInterval(1.5)
         try? data.write(to: storeURL, options: .atomic)
@@ -697,7 +871,13 @@ final class ClipboardStore {
 
     private func mergeExternal(_ snap: Snapshot) {
         let before = history.count
-        var combined = (history + snap.history).sorted { $0.createdAt > $1.createdAt }
+        deletionLedger.merge(snap.deletionLedger ?? ClipDeletionLedger())
+        let deletedIDs = deletionLedger.deletedIDs
+        let isDeleted: (ClipItem) -> Bool = { deletedIDs.contains($0.id) }
+
+        var combined = (history + snap.history)
+            .filter { !isDeleted($0) }
+            .sorted { $0.createdAt > $1.createdAt }
         var seen = Set<String>()
         var merged: [ClipItem] = []
         for it in combined where seen.insert(contentKey(it)).inserted { merged.append(it) }
@@ -707,18 +887,23 @@ final class ClipboardStore {
         var byID: [UUID: Pinboard] = Dictionary(uniqueKeysWithValues: pinboards.map { ($0.id, $0) })
         for b in snap.pinboards {
             if var existing = byID[b.id] {
-                for it in b.items where !existing.items.contains(where: { $0.sameContent(as: it) }) {
+                for it in b.items
+                where !isDeleted(it) && !existing.items.contains(where: { $0.sameContent(as: it) }) {
                     existing.items.append(it)
                 }
+                existing.items.removeAll(where: isDeleted)
                 byID[b.id] = existing
             } else {
-                byID[b.id] = b
+                var filtered = b
+                filtered.items.removeAll(where: isDeleted)
+                byID[b.id] = filtered
             }
         }
         pinboards = pinboards.map { byID[$0.id] ?? $0 }
             + byID.values.filter { b in !pinboards.contains(where: { $0.id == b.id }) }
 
         combined.removeAll()
+        _ = refreshDeletionState(at: .now)
         selectFirst()
         if history.count != before || !snap.history.isEmpty { saveNow() }
     }

--- a/Sources/Pesty/UI/BarView.swift
+++ b/Sources/Pesty/UI/BarView.swift
@@ -45,6 +45,9 @@ struct BarView: View {
             if store.multiSelectedIDs.count > 1 {
                 bulkDeleteButton
             }
+            if store.hasUndoableDeletion {
+                undoButton
+            }
             moreMenu
         }
         .padding(.horizontal, 18)
@@ -102,6 +105,24 @@ struct BarView: View {
         .controlSize(.small)
         .help("Delete \(count) selected clips (⌘⌫)")
         .accessibilityLabel("Delete \(count) selected clips")
+    }
+
+    private var undoButton: some View {
+        Button {
+            store.undoLastDelete()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.uturn.backward")
+                Text("Undo")
+            }
+            .font(.system(size: 12.5, weight: .medium))
+            .lineLimit(1)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .fixedSize()
+        .help("Undo the last deletion (⌘Z) — available for 5 minutes")
+        .accessibilityLabel("Undo last deletion")
     }
 
     private var moreMenu: some View {

--- a/Sources/Pesty/UI/ClipCardView.swift
+++ b/Sources/Pesty/UI/ClipCardView.swift
@@ -262,7 +262,8 @@ struct ClipCardView: View {
         Divider()
 
         Button(role: .destructive) {
-            AppController.shared.deleteSelection(containing: item)
+            let optionHeld = NSEvent.modifierFlags.contains(.option)
+            AppController.shared.deleteSelection(containing: item, permanently: optionHeld)
         } label: {
             Label(deleteMenuTitle, systemImage: "trash")
         }


### PR DESCRIPTION
Deleting a clip is currently final and one keystroke away. This gives a deleted clip five minutes in which ⌘Z puts it back exactly where it was, with an opt-out for users who don't want deleted content recoverable at all.

## What changed

- `ClipDeletionLedger` records each deleted clip's exact placement (index, predecessor, successor) in whichever container it came from. The payload is kept separate from a small durable tombstone, so a stale synced snapshot can't resurrect an intentional deletion. Payloads are dropped after five minutes; tombstones stay.
- ⌘Z restores the most recent still-undoable deletion at its original position; repeated presses walk back through independent deletions in order.
- An Undo button appears in the bar's top-right while anything is still recoverable, and the bulk-delete confirmation now says so instead of "There is no undo."
- A "Delete permanently" setting (off by default) skips the ledger entirely, plus a per-deletion Option-key override that bypasses Undo for that one deletion regardless of the setting.
- Ledgered clips' image files are protected from cleanup while they're still restorable.

## Screenshots


**Before:**
![00-baseline screenshots bar.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/00-baseline/screenshots/bar.png)

**After:**
![07-undo screenshots bar.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/07-undo/screenshots/bar.png)
![07-undo screenshots settings.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/07-undo/screenshots/settings.png)

## Notes for review

- **Clear History and deleting a whole Pinboard are deliberately outside the ledger.** Both are bulk operations: ledgering them means holding the entire history — every image file included — recoverable in `store.json` for five minutes, which is exactly the retention users who reach for "Clear History" are trying to avoid, and a payload the ledger's per-deletion design isn't shaped for. Single-clip deletion is the frequent accidental one and is what this covers. Clear History keeps its existing confirmation; deleting a Pinboard keeps its existing behavior. Both are unchanged by this PR, not newly excepted by it — happy to add a confirm to Clear History in a follow-up if you'd rather.
- The Option-key bypass and the Settings override both apply per deletion; neither retroactively purges an existing ledger entry beyond the normal five-minute expiry.
- No dependencies; merges in any order.

---

**This feature should be bundled into v2.**

Part of #80.
