### PR TITLE
Add a "Play sound on copy" setting

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -326,6 +326,8 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func copyItem(_ item: ClipItem) {
         let change = PasteService.copy(item)
         monitor.suppressUntilChangeCount = change
+        // Tink, not Pop: copy and paste stay audibly distinct.
+        if Settings.shared.playSoundOnCopy { NSSound(named: "Tink")?.play() }
         hideBar()
     }
 

--- a/Sources/Pesty/Settings/Settings.swift
+++ b/Sources/Pesty/Settings/Settings.swift
@@ -212,7 +212,9 @@ final class Settings {
             Keys.hideOnClickOutside: true,
             Keys.pasteDirectly: true,
             Keys.playSound: false,
-            Keys.playSoundOnCopy: true,
+            // Off by default, matching the paste sound: existing users
+            // shouldn't gain a new audible behavior from an update.
+            Keys.playSoundOnCopy: false,
             Keys.ignoreConcealed: true,
             Keys.ignoredSourceAppBundleIDs: [],
             Keys.barHeight: 430.0,

--- a/Sources/Pesty/Settings/Settings.swift
+++ b/Sources/Pesty/Settings/Settings.swift
@@ -79,6 +79,7 @@ final class Settings {
         static let hideOnClickOutside = "hideOnClickOutside"
         static let pasteDirectly = "pasteDirectly"
         static let playSound = "playSound"
+        static let playSoundOnCopy = "playSoundOnCopy"
         static let ignoreConcealed = "ignoreConcealed"
         static let ignoredSourceAppBundleIDs = "ignoredSourceAppBundleIDs"
         static let barHeight = "barHeight"
@@ -154,6 +155,10 @@ final class Settings {
         didSet { guard isLoaded else { return }; d.set(playSound, forKey: Keys.playSound) }
     }
 
+    var playSoundOnCopy: Bool {
+        didSet { guard isLoaded else { return }; d.set(playSoundOnCopy, forKey: Keys.playSoundOnCopy) }
+    }
+
     var ignoreConcealed: Bool {
         didSet { guard isLoaded else { return }; d.set(ignoreConcealed, forKey: Keys.ignoreConcealed) }
     }
@@ -207,6 +212,7 @@ final class Settings {
             Keys.hideOnClickOutside: true,
             Keys.pasteDirectly: true,
             Keys.playSound: false,
+            Keys.playSoundOnCopy: true,
             Keys.ignoreConcealed: true,
             Keys.ignoredSourceAppBundleIDs: [],
             Keys.barHeight: 430.0,
@@ -227,6 +233,7 @@ final class Settings {
         hideOnClickOutside = d.bool(forKey: Keys.hideOnClickOutside)
         pasteDirectly = d.bool(forKey: Keys.pasteDirectly)
         playSound = d.bool(forKey: Keys.playSound)
+        playSoundOnCopy = d.bool(forKey: Keys.playSoundOnCopy)
         ignoreConcealed = d.bool(forKey: Keys.ignoreConcealed)
         ignoredSourceAppBundleIDs = (d.stringArray(forKey: Keys.ignoredSourceAppBundleIDs) ?? [])
             .filter { !$0.isEmpty }

--- a/Sources/Pesty/Settings/SettingsView.swift
+++ b/Sources/Pesty/Settings/SettingsView.swift
@@ -133,6 +133,7 @@ private struct GeneralSettings: View {
                 #endif
                 Toggle("Ignore passwords (concealed clips)", isOn: $settings.ignoreConcealed)
                 Toggle("Play sound on paste", isOn: $settings.playSound)
+                Toggle("Play sound on copy", isOn: $settings.playSoundOnCopy)
                 Toggle("Hide Pesty when clicking outside", isOn: $settings.hideOnClickOutside)
                 Toggle("Launch at login", isOn: $settings.launchAtLogin)
                 Toggle("Show Pesty in the menu bar", isOn: $settings.showMenuBarIcon)


### PR DESCRIPTION
Pesty can already play a sound on paste. This adds the sibling toggle for copy, using an audibly distinct system sound so the two events aren't confusable.

## What changed

- New "Play sound on copy" setting, **off by default**, playing the system "Tink" sound when a clip is copied from the bar via `copyItem(_:)`.
- Kept distinct from the existing "Play sound on paste" toggle, which plays "Pop" from `PasteService.paste(_:)`.

## Screenshots


**Before:**
![00-baseline screenshots settings-general.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/00-baseline/screenshots/settings-general.png)

**After:**
![09-play-sound-on-copy screenshots after.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/09-play-sound-on-copy/screenshots/after.png)

## Notes for review

- Deliberately defaults **off**, matching the existing paste sound. An update shouldn't introduce a new audible behavior nobody asked for, and two sibling toggles shipping with opposite defaults would read as an oversight.
- No dependencies; merges in any order.

---

**This feature should be bundled into v2.**

Part of #80.
