### PR TITLE
Show history's on-disk size in Settings

### DIFF
--- a/Sources/Pesty/Settings/SettingsView.swift
+++ b/Sources/Pesty/Settings/SettingsView.swift
@@ -242,11 +242,41 @@ private struct HistoryRetentionSettings: View {
     @State private var draftDays = Settings.shared.historyRetentionDays
     @State private var pendingRemovalCount = 0
     @State private var confirmingChange = false
+    @State private var storageBytes: Int64?
 
     private static let dayChoices: [(days: Int, label: String)] = [
         (1, "1 Day"), (7, "1 Week"), (14, "2 Weeks"), (30, "1 Month"),
         (90, "3 Months"), (180, "6 Months"), (365, "1 Year")
     ]
+
+    private var storageSummary: String {
+        let count = ClipboardStore.shared.history.count
+        let clips = "\(count) clip\(count == 1 ? "" : "s")"
+        guard let storageBytes else { return clips }
+        return "\(clips) · \(ByteCountFormatter.string(fromByteCount: storageBytes, countStyle: .file))"
+    }
+
+    private func refreshStorageSize() async {
+        let dir = ClipboardStore.shared.dataDirectory
+        storageBytes = await Task.detached(priority: .utility) {
+            Self.directorySize(at: dir)
+        }.value
+    }
+
+    /// Walks the store directory off the main actor; images can make it
+    /// large enough that a synchronous walk would hitch the Settings window.
+    nonisolated private static func directorySize(at url: URL) -> Int64 {
+        let keys: Set<URLResourceKey> = [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey, .isRegularFileKey]
+        guard let enumerator = FileManager.default.enumerator(at: url,
+                                                              includingPropertiesForKeys: Array(keys)) else { return 0 }
+        var total: Int64 = 0
+        for case let file as URL in enumerator {
+            guard let values = try? file.resourceValues(forKeys: keys),
+                  values.isRegularFile == true else { continue }
+            total += Int64(values.totalFileAllocatedSize ?? values.fileAllocatedSize ?? 0)
+        }
+        return total
+    }
 
     var body: some View {
         Section("History") {
@@ -270,7 +300,9 @@ private struct HistoryRetentionSettings: View {
             Text(footnote)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+            LabeledContent("Currently storing", value: storageSummary)
         }
+        .task { await refreshStorageSize() }
         .onChange(of: draftMode) { evaluateDraft() }
         .onChange(of: draftLimit) { evaluateDraft() }
         .onChange(of: draftDays) { evaluateDraft() }

--- a/Sources/Pesty/Store/ClipboardStore.swift
+++ b/Sources/Pesty/Store/ClipboardStore.swift
@@ -66,6 +66,10 @@ final class ClipboardStore {
 
     var iCloudAvailable: Bool { ClipboardStore.iCloudBase != nil }
 
+    /// The on-disk store root (history JSON plus saved images), exposed so
+    /// Settings can report how much space history actually uses.
+    var dataDirectory: URL { baseDir }
+
     private init() {
         let base = (Settings.shared.iCloudSync ? ClipboardStore.iCloudBase : nil) ?? ClipboardStore.localBase
         baseDir = base


### PR DESCRIPTION
Retention settings ask you to decide how much history to keep without telling you what it currently costs. The Keep History section now reports it.

## What changed

- A "Currently storing" row in Keep History shows the clip count plus the store directory's actual size on disk — history JSON and saved images together.
- The directory walk runs off the main actor when the pane opens, so a large image library can't hitch the Settings window.

## Screenshots


**Before:**
![00-baseline screenshots bar.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/00-baseline/screenshots/bar.png)

**After:**
![10-history-disk-size screenshots after.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/10-history-disk-size/screenshots/after.png)

## Notes for review

- The size is measured when the pane opens, not polled — it won't tick live while the pane is showing.
- No dependencies; merges in any order. Pairs naturally with the retention slider PR but doesn't require it.

---

**This feature should be bundled into v2.**

Part of #80.
