### PR TITLE
Fix search-mode Command-Delete, silent paste failures, and buried pasted clips

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -321,12 +321,36 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
         let target = pasteTarget
         hideBar()
         PasteService.paste(item, into: target, monitor: monitor, asPlainText: asPlainText)
+        if Settings.shared.promoteOnPaste {
+            store.promoteCopiedItem(item)
+        }
     }
 
     func copyItem(_ item: ClipItem) {
         let change = PasteService.copy(item)
         monitor.suppressUntilChangeCount = change
         hideBar()
+    }
+
+    private var warnedAccessibilityThisLaunch = false
+
+    /// Direct paste silently degrading to copy-only reads as "paste is
+    /// broken". Explain once per launch, with a shortcut to the grant.
+    func reportMissingAccessibilityForDirectPaste() {
+        guard !warnedAccessibilityThisLaunch else { return }
+        warnedAccessibilityThisLaunch = true
+        suppressAutoHide = true
+        defer { suppressAutoHide = false }
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = "Pesty can\u{2019}t paste directly"
+        alert.informativeText = "The clip was copied, but macOS is blocking the automatic \u{2318}V because Accessibility permission isn\u{2019}t granted (a rebuilt app needs re-granting). Paste manually with \u{2318}V, or grant access in System Settings \u{2192} Privacy & Security \u{2192} Accessibility."
+        alert.addButton(withTitle: "Open System Settings")
+        alert.addButton(withTitle: "OK")
+        if alert.runModal() == .alertFirstButtonReturn,
+           let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     var pasteMenuTitle: String {
@@ -529,6 +553,14 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
         case kVK_RightArrow, kVK_DownArrow:
             store.moveSelection(by: 1); return nil
         case kVK_Delete:
+            // ⌘⌫ while a query is being edited means "delete to line start"
+            // in the field, never "destroy the selected clip" - text-field
+            // semantics win the whole time there's a query to clear.
+            if cmd, !store.searchText.isEmpty {
+                store.searchText = ""; store.selectFirst()
+                searchClearedAt = Date()
+                return nil
+            }
             if cmd { deleteEffectiveSelection(); return nil }
             if !store.searchText.isEmpty {
                 store.searchText.removeLast(); store.selectFirst()

--- a/Sources/Pesty/Monitor/PasteService.swift
+++ b/Sources/Pesty/Monitor/PasteService.swift
@@ -71,7 +71,13 @@ enum PasteService {
         #else
         // Direct-download build: optionally paste straight into the active app by
         // synthesizing ⌘V. This requires the user's Accessibility grant.
-        guard Settings.shared.pasteDirectly && AXIsProcessTrusted() else { return }
+        guard Settings.shared.pasteDirectly else { return }
+        guard AXIsProcessTrusted() else {
+            // Silently doing nothing here reads as "paste is broken" - every
+            // rebuild invalidates the TCC grant, so this is a common state.
+            AppController.shared.reportMissingAccessibilityForDirectPaste()
+            return
+        }
         target.activate()
         waitForFrontmost(target, attempts: 20)
         #endif

--- a/Sources/Pesty/Settings/Settings.swift
+++ b/Sources/Pesty/Settings/Settings.swift
@@ -79,6 +79,7 @@ final class Settings {
         static let hideOnClickOutside = "hideOnClickOutside"
         static let pasteDirectly = "pasteDirectly"
         static let playSound = "playSound"
+        static let promoteOnPaste = "promoteOnPaste"
         static let ignoreConcealed = "ignoreConcealed"
         static let ignoredSourceAppBundleIDs = "ignoredSourceAppBundleIDs"
         static let barHeight = "barHeight"
@@ -154,6 +155,10 @@ final class Settings {
         didSet { guard isLoaded else { return }; d.set(playSound, forKey: Keys.playSound) }
     }
 
+    var promoteOnPaste: Bool {
+        didSet { guard isLoaded else { return }; d.set(promoteOnPaste, forKey: Keys.promoteOnPaste) }
+    }
+
     var ignoreConcealed: Bool {
         didSet { guard isLoaded else { return }; d.set(ignoreConcealed, forKey: Keys.ignoreConcealed) }
     }
@@ -207,6 +212,7 @@ final class Settings {
             Keys.hideOnClickOutside: true,
             Keys.pasteDirectly: true,
             Keys.playSound: false,
+            Keys.promoteOnPaste: true,
             Keys.ignoreConcealed: true,
             Keys.ignoredSourceAppBundleIDs: [],
             Keys.barHeight: 430.0,
@@ -227,6 +233,7 @@ final class Settings {
         hideOnClickOutside = d.bool(forKey: Keys.hideOnClickOutside)
         pasteDirectly = d.bool(forKey: Keys.pasteDirectly)
         playSound = d.bool(forKey: Keys.playSound)
+        promoteOnPaste = d.bool(forKey: Keys.promoteOnPaste)
         ignoreConcealed = d.bool(forKey: Keys.ignoreConcealed)
         ignoredSourceAppBundleIDs = (d.stringArray(forKey: Keys.ignoredSourceAppBundleIDs) ?? [])
             .filter { !$0.isEmpty }

--- a/Sources/Pesty/Settings/SettingsView.swift
+++ b/Sources/Pesty/Settings/SettingsView.swift
@@ -132,6 +132,7 @@ private struct GeneralSettings: View {
                 Toggle("Paste directly into the active app", isOn: $settings.pasteDirectly)
                 #endif
                 Toggle("Ignore passwords (concealed clips)", isOn: $settings.ignoreConcealed)
+                Toggle("Move pasted clips to the top of history", isOn: $settings.promoteOnPaste)
                 Toggle("Play sound on paste", isOn: $settings.playSound)
                 Toggle("Hide Pesty when clicking outside", isOn: $settings.hideOnClickOutside)
                 Toggle("Launch at login", isOn: $settings.launchAtLogin)

--- a/Sources/Pesty/Store/ClipboardStore.swift
+++ b/Sources/Pesty/Store/ClipboardStore.swift
@@ -123,6 +123,12 @@ final class ClipboardStore {
         scheduleSave()
     }
 
+    func promoteCopiedItem(_ item: ClipItem, at date: Date = .now) {
+        var copied = item
+        copied.createdAt = date
+        addCaptured(copied)
+    }
+
     func applyRetentionPolicy() { trimHistory(); scheduleSave() }
 
     func retentionRemovalCount(mode: HistoryRetentionMode, limit: Int, days: Int) -> Int {


### PR DESCRIPTION
Three things that make pasting feel unreliable: ⌘⌫ destroying a clip when you meant to clear the search, a paste that silently does nothing when Accessibility isn't granted, and a clip you just pasted staying wherever it was in history.

## What changed

- ⌘⌫ while a search query is being edited clears the query instead of deleting the selected clip. The cmd check previously ran before the search-text check, so it always won regardless of what was being typed.
- A paste blocked by a missing Accessibility grant no longer no-ops silently: a once-per-launch alert explains the clip was still copied, that ⌘V pastes it manually, and links to the Accessibility pane. This is a common state — every rebuild invalidates the grant.
- Pasting can promote the clip to the top of history, matching how Copy already behaves. It's a Behavior toggle; turning it off restores the old stay-in-place ordering.

## Screenshots


**Before:**
![00-baseline screenshots bar.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/00-baseline/screenshots/bar.png)

**After:**
![11-paste-reliability screenshots after.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/11-paste-reliability/screenshots/after.png)

The ⌘⌫ fix has no visual delta — it's a key-handling correction, shown only by the query surviving the keystroke.

## Notes for review

- **`promoteOnPaste` ships ON by default, and that's deliberate.** Pasting a clip is a re-use of it, exactly like copying one, and Copy already reorders history this way — shipping the two with opposite defaults would be the inconsistency. It's a silent reordering for existing users, so it gets a Behavior toggle that restores the old ordering in one click. Happy to flip the default if you'd rather; the toggle exists either way.
- The Accessibility alert is compiled out of the MAS build (the `#if MAS` branch never reaches it) — verified, so there's no App Store review surface here.
- Merge-order note: `alvie/pr-cmd-c-copy` adds a byte-identical `ClipboardStore.promoteCopiedItem(_:at:)`. Git puts them in different regions of the file, so it will **not** conflict — it will produce two identical methods and a redeclaration error. Whichever merges second, delete the duplicate.

---

**This feature should be bundled into v2.**

Part of #80.
