### PR TITLE
Add Clean Formatting and Markdown paste options

### DIFF
--- a/Sources/Pesty/AppController.swift
+++ b/Sources/Pesty/AppController.swift
@@ -317,10 +317,10 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
         return app.bundleIdentifier == bundleID
     }
 
-    func pasteItem(_ item: ClipItem, asPlainText: Bool = false) {
+    func pasteItem(_ item: ClipItem, format: PasteFormat = .original) {
         let target = pasteTarget
         hideBar()
-        PasteService.paste(item, into: target, monitor: monitor, asPlainText: asPlainText)
+        PasteService.paste(item, into: target, monitor: monitor, format: format)
     }
 
     func copyItem(_ item: ClipItem) {
@@ -508,7 +508,7 @@ final class AppController: NSObject, NSApplicationDelegate, NSWindowDelegate {
             if digit <= items.count {
                 let plain = includes(Settings.shared.plainTextModifier, in: flags)
                     && Settings.shared.plainTextModifier != Settings.shared.quickPasteModifier
-                pasteItem(items[digit - 1], asPlainText: plain)
+                pasteItem(items[digit - 1], format: plain ? .plainText : .original)
             }
             return nil
         }

--- a/Sources/Pesty/Models/ClipItem.swift
+++ b/Sources/Pesty/Models/ClipItem.swift
@@ -5,6 +5,7 @@ struct ClipItem: Identifiable, Codable, Equatable {
     var type: ClipType
     var text: String?
     var rtfData: Data?
+    var htmlData: Data?
     var imageFileName: String?
     var imageHash: String?
     var fileURLs: [String]
@@ -20,6 +21,7 @@ struct ClipItem: Identifiable, Codable, Equatable {
          type: ClipType,
          text: String? = nil,
          rtfData: Data? = nil,
+         htmlData: Data? = nil,
          imageFileName: String? = nil,
          imageHash: String? = nil,
          fileURLs: [String] = [],
@@ -32,6 +34,7 @@ struct ClipItem: Identifiable, Codable, Equatable {
         self.type = type
         self.text = text
         self.rtfData = rtfData
+        self.htmlData = htmlData
         self.imageFileName = imageFileName
         self.imageHash = imageHash
         self.fileURLs = fileURLs

--- a/Sources/Pesty/Monitor/ClipboardMonitor.swift
+++ b/Sources/Pesty/Monitor/ClipboardMonitor.swift
@@ -101,8 +101,13 @@ final class ClipboardMonitor {
         let rtf = pasteboard.data(forType: .rtf)
         // Browsers often provide HTML with no RTF; keep it for the Markdown
         // and Clean Formatting paste conversions without changing how the
-        // clip is classified.
-        let html = pasteboard.data(forType: .html)
+        // clip is classified. Cap it at the same bound the sync layer uses
+        // for inline text/rtf payloads (CKSchema.inlineLimit) so a routine
+        // copy can't persist an unbounded HTML blob with every clip —
+        // oversized HTML is simply dropped and the paste conversions fall
+        // back to RTF/plain text as they did before HTML capture existed.
+        var html = pasteboard.data(forType: .html)
+        if let data = html, data.count > CKSchema.inlineLimit { html = nil }
         if let string = pasteboard.string(forType: .string), !string.isEmpty {
             let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
             let type: ClipType

--- a/Sources/Pesty/Monitor/ClipboardMonitor.swift
+++ b/Sources/Pesty/Monitor/ClipboardMonitor.swift
@@ -99,6 +99,10 @@ final class ClipboardMonitor {
         }
 
         let rtf = pasteboard.data(forType: .rtf)
+        // Browsers often provide HTML with no RTF; keep it for the Markdown
+        // and Clean Formatting paste conversions without changing how the
+        // clip is classified.
+        let html = pasteboard.data(forType: .html)
         if let string = pasteboard.string(forType: .string), !string.isEmpty {
             let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
             let type: ClipType
@@ -109,7 +113,7 @@ final class ClipboardMonitor {
             } else {
                 type = .text
             }
-            var item = ClipItem(type: type, text: string, rtfData: rtf)
+            var item = ClipItem(type: type, text: string, rtfData: rtf, htmlData: html)
             decorate(&item)
             return item
         }

--- a/Sources/Pesty/Monitor/PasteService.swift
+++ b/Sources/Pesty/Monitor/PasteService.swift
@@ -1,6 +1,19 @@
 import AppKit
 import Carbon.HIToolbox
 
+/// How a clip's content is written to the pasteboard when pasting.
+enum PasteFormat {
+    /// The clip exactly as captured.
+    case original
+    /// Text only, all formatting removed.
+    case plainText
+    /// Bold, italic, underline, and links survive; fonts, sizes, and colors
+    /// are normalized away.
+    case cleanFormatting
+    /// Rich content converted to Markdown text.
+    case markdown
+}
+
 @MainActor
 enum PasteService {
     private static let sourceType = NSPasteboard.PasteboardType("org.nspasteboard.source")
@@ -13,13 +26,40 @@ enum PasteService {
 
     @discardableResult
     static func copy(_ item: ClipItem,
-                     asPlainText: Bool = false,
+                     format: PasteFormat = .original,
                      to pasteboard: NSPasteboard = .general) -> Int {
-        if asPlainText, let text = item.plainText {
-            pasteboard.clearContents()
-            pasteboard.setString(text, forType: .string)
-            markSource(of: item, on: pasteboard)
-            return pasteboard.changeCount
+        switch format {
+        case .plainText:
+            if let text = item.plainText {
+                pasteboard.clearContents()
+                pasteboard.setString(text, forType: .string)
+                markSource(of: item, on: pasteboard)
+                return pasteboard.changeCount
+            }
+        case .cleanFormatting:
+            if let rtf = FormatConverter.cleanedRTF(for: item) {
+                pasteboard.clearContents()
+                pasteboard.setData(rtf, forType: .rtf)
+                if let text = item.plainText { pasteboard.setString(text, forType: .string) }
+                markSource(of: item, on: pasteboard)
+                return pasteboard.changeCount
+            }
+            // No rich source to clean: plain text is the honest result.
+            if item.plainText != nil {
+                return copy(item, format: .plainText, to: pasteboard)
+            }
+        case .markdown:
+            if let markdown = FormatConverter.markdown(for: item) {
+                pasteboard.clearContents()
+                pasteboard.setString(markdown, forType: .string)
+                markSource(of: item, on: pasteboard)
+                return pasteboard.changeCount
+            }
+            if item.plainText != nil {
+                return copy(item, format: .plainText, to: pasteboard)
+            }
+        case .original:
+            break
         }
         if item.type == .image {
             guard let img = ClipboardStore.shared.loadImage(for: item) else {
@@ -56,8 +96,8 @@ enum PasteService {
     static func paste(_ item: ClipItem,
                       into targetApp: NSRunningApplication?,
                       monitor: ClipboardMonitor,
-                      asPlainText: Bool = false) {
-        let change = copy(item, asPlainText: asPlainText)
+                      format: PasteFormat = .original) {
+        let change = copy(item, format: format)
         monitor.suppressUntilChangeCount = change
         if Settings.shared.playSound { NSSound(named: "Pop")?.play() }
 

--- a/Sources/Pesty/UI/ClipCardView.swift
+++ b/Sources/Pesty/UI/ClipCardView.swift
@@ -197,10 +197,20 @@ struct ClipCardView: View {
             Label(AppController.shared.pasteMenuTitle, systemImage: "doc.on.clipboard")
         }
 
-        Button { AppController.shared.pasteItem(item, asPlainText: true) } label: {
+        Button { AppController.shared.pasteItem(item, format: .plainText) } label: {
             Label("Paste as Plain Text", systemImage: "text.alignleft")
         }
         .disabled(item.plainText == nil)
+
+        Button { AppController.shared.pasteItem(item, format: .cleanFormatting) } label: {
+            Label("Paste with Clean Formatting", systemImage: "paintbrush")
+        }
+        .disabled(!FormatConverter.canConvert(item))
+
+        Button { AppController.shared.pasteItem(item, format: .markdown) } label: {
+            Label("Paste as Markdown", systemImage: "number")
+        }
+        .disabled(!FormatConverter.canConvert(item))
 
         Button { AppController.shared.copyItem(item) } label: {
             Label("Copy", systemImage: "doc.on.doc")

--- a/Sources/Pesty/Util/FormatConverter.swift
+++ b/Sources/Pesty/Util/FormatConverter.swift
@@ -4,16 +4,68 @@ import AppKit
 /// options. HTML is preferred as the source when the clip carried it —
 /// browser copies often have no RTF at all — with RTF as the fallback.
 enum FormatConverter {
+    /// Above this, skip rich conversion entirely and let the caller fall back
+    /// to plain text. The HTML importer runs synchronously on the main thread
+    /// at paste time; a pathological clip must not hitch the paste.
+    private static let maxRichSourceBytes = 1_000_000
+
     static func canConvert(_ item: ClipItem) -> Bool {
-        item.htmlData != nil || item.rtfData != nil
+        withinLimit(item.htmlData) || withinLimit(item.rtfData)
+    }
+
+    private static func withinLimit(_ data: Data?) -> Bool {
+        guard let data else { return false }
+        return !data.isEmpty && data.count <= maxRichSourceBytes
+    }
+
+    /// Removes every element that could make the HTML importer touch the
+    /// network. `NSAttributedString(html:)` is WebKit-backed and will fetch
+    /// remote subresources — `<img src="http...">` tracking pixels included —
+    /// synchronously, on the main thread, at paste time. That would break the
+    /// app's no-network-calls promise and stall the paste, so the offending
+    /// elements are dropped wholesale before conversion: the converters only
+    /// keep text plus bold/italic/underline/links, and images, scripts, and
+    /// stylesheets aren't representable in the output anyway.
+    private static func sanitizedHTML(_ data: Data) -> Data? {
+        guard let raw = String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .utf16) else { return nil }
+        var html = raw
+
+        func drop(_ pattern: String) {
+            html = html.replacingOccurrences(of: pattern, with: "",
+                                             options: [.regularExpression, .caseInsensitive])
+        }
+
+        // Container elements go with their entire contents…
+        for tag in ["script", "style", "iframe", "object", "picture", "svg", "video", "audio"] {
+            drop("<\(tag)\\b[^>]*>[\\s\\S]*?</\(tag)\\s*>")
+            // …and any unbalanced leftovers of the same tags.
+            drop("<\(tag)\\b[^>]*/?>")
+            drop("</\(tag)\\s*>")
+        }
+        // Void/self-closing elements that reference external resources.
+        for tag in ["img", "source", "embed", "link"] {
+            drop("<\(tag)\\b[^>]*/?>")
+        }
+        // Neutralize CSS url(...) in surviving style attributes
+        // (background images are fetched too).
+        html = html.replacingOccurrences(of: "url\\s*\\([^)]*\\)", with: "none",
+                                         options: [.regularExpression, .caseInsensitive])
+        return html.data(using: .utf8)
     }
 
     private static func attributed(for item: ClipItem) -> NSAttributedString? {
-        if let html = item.htmlData,
-           let s = NSAttributedString(html: html, documentAttributes: nil) {
+        if let html = item.htmlData, withinLimit(html),
+           let safe = sanitizedHTML(html),
+           let s = NSAttributedString(html: safe,
+                                      // Belt-and-braces alongside the stripping
+                                      // above: never let the importer wait on a
+                                      // (now nonexistent) subresource load.
+                                      options: [.timeout: 2.0],
+                                      documentAttributes: nil) {
             return s
         }
-        if let rtf = item.rtfData,
+        if let rtf = item.rtfData, withinLimit(rtf),
            let s = NSAttributedString(rtf: rtf, documentAttributes: nil) {
             return s
         }

--- a/Sources/Pesty/Util/FormatConverter.swift
+++ b/Sources/Pesty/Util/FormatConverter.swift
@@ -1,0 +1,101 @@
+import AppKit
+
+/// Converts rich clips for the "Clean Formatting" and "Markdown" paste
+/// options. HTML is preferred as the source when the clip carried it —
+/// browser copies often have no RTF at all — with RTF as the fallback.
+enum FormatConverter {
+    static func canConvert(_ item: ClipItem) -> Bool {
+        item.htmlData != nil || item.rtfData != nil
+    }
+
+    private static func attributed(for item: ClipItem) -> NSAttributedString? {
+        if let html = item.htmlData,
+           let s = NSAttributedString(html: html, documentAttributes: nil) {
+            return s
+        }
+        if let rtf = item.rtfData,
+           let s = NSAttributedString(rtf: rtf, documentAttributes: nil) {
+            return s
+        }
+        return nil
+    }
+
+    /// Strips fonts, sizes, and colors while keeping the structure people
+    /// mean when they say "formatting": bold, italic, underline,
+    /// strikethrough, and links — everything else becomes the system font.
+    static func cleanedRTF(for item: ClipItem) -> Data? {
+        guard let source = attributed(for: item) else { return nil }
+        let base = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        let out = NSMutableAttributedString(string: source.string)
+        let full = NSRange(location: 0, length: out.length)
+        out.addAttribute(.font, value: base, range: full)
+
+        source.enumerateAttributes(in: NSRange(location: 0, length: source.length)) { attrs, range, _ in
+            if let font = attrs[.font] as? NSFont {
+                var kept: NSFontDescriptor.SymbolicTraits = []
+                let traits = font.fontDescriptor.symbolicTraits
+                if traits.contains(.bold) { kept.insert(.bold) }
+                if traits.contains(.italic) { kept.insert(.italic) }
+                if !kept.isEmpty,
+                   let styled = NSFont(descriptor: base.fontDescriptor.withSymbolicTraits(kept),
+                                       size: base.pointSize) {
+                    out.addAttribute(.font, value: styled, range: range)
+                }
+            }
+            if let underline = attrs[.underlineStyle] {
+                out.addAttribute(.underlineStyle, value: underline, range: range)
+            }
+            if let strike = attrs[.strikethroughStyle] {
+                out.addAttribute(.strikethroughStyle, value: strike, range: range)
+            }
+            if let link = attrs[.link] {
+                out.addAttribute(.link, value: link, range: range)
+            }
+        }
+        return out.rtf(from: full)
+    }
+
+    /// Walks the attributed runs producing Markdown for bold, italic, and
+    /// links. Markers never wrap line breaks — each line segment inside a
+    /// styled run is marked separately so the output stays valid Markdown.
+    static func markdown(for item: ClipItem) -> String? {
+        guard let source = attributed(for: item) else { return nil }
+        var out = ""
+        let text = source.string as NSString
+
+        source.enumerateAttributes(in: NSRange(location: 0, length: source.length)) { attrs, range, _ in
+            let chunk = text.substring(with: range)
+            guard !chunk.isEmpty else { return }
+
+            let traits = (attrs[.font] as? NSFont)?.fontDescriptor.symbolicTraits ?? []
+            var marker = ""
+            if traits.contains(.bold) { marker += "**" }
+            if traits.contains(.italic) { marker += "*" }
+            let linkTarget: String? = (attrs[.link] as? URL)?.absoluteString
+                ?? attrs[.link] as? String
+
+            // Split on newlines, keeping empty segments so blank lines survive.
+            let segments = chunk.components(separatedBy: "\n")
+            for (index, segment) in segments.enumerated() {
+                if index > 0 { out += "\n" }
+                guard !segment.isEmpty else { continue }
+                // Markers hug the visible text; whitespace stays outside them.
+                let leading = segment.prefix(while: { $0 == " " || $0 == "\t" })
+                let trailing = String(segment.reversed().prefix(while: { $0 == " " || $0 == "\t" }).reversed())
+                let core = segment.dropFirst(leading.count).dropLast(trailing.count)
+                guard !core.isEmpty else { out += segment; continue }
+
+                var rendered = String(core)
+                if let linkTarget, rendered.trimmingCharacters(in: .whitespaces) != linkTarget {
+                    rendered = "[\(rendered)](\(linkTarget))"
+                }
+                if !marker.isEmpty {
+                    rendered = "\(marker)\(rendered)\(String(marker.reversed()))"
+                }
+                out += leading + rendered + trailing
+            }
+        }
+        let trimmed = out.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/Pesty/Util/FormatConverter.swift
+++ b/Sources/Pesty/Util/FormatConverter.swift
@@ -144,7 +144,7 @@ enum FormatConverter {
                 if !marker.isEmpty {
                     rendered = "\(marker)\(rendered)\(String(marker.reversed()))"
                 }
-                out += leading + rendered + trailing
+                out += String(leading) + rendered + trailing
             }
         }
         let trimmed = out.trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
"Paste as Plain Text" is all-or-nothing: it's the only escape from a clip that arrives with a website's fonts and colors attached. This adds two middle options — keep the emphasis, drop the styling, or convert to Markdown.

## What changed

- Two new context-menu paste modes alongside Paste as Plain Text, enabled whenever a clip has rich content. **Clean Formatting** keeps bold, italic, underline, strikethrough, and links while normalizing fonts, sizes, and colors to the system default. **Markdown** converts rich content to Markdown text, splitting style markers across line breaks so the output stays valid, and rendering links as `[text](url)`.
- The monitor also captures a copy's HTML flavor — browser copies often carry HTML with no RTF — without changing how clips are classified or deduplicated. Conversions prefer HTML, then RTF, then plain text.
- Paste plumbing moves from an `asPlainText` flag to a `PasteFormat` enum carrying all four modes.
- The HTML importer is WebKit-backed and will fetch remote subresources during conversion, so every element that can reference an external resource (`img`, `picture`, `source`, `iframe`, `object`, `embed`, `link`, `script`, `style`, `svg`, `video`, `audio`, and CSS `url()`) is stripped before conversion, backed by a 2-second importer timeout. Sources over 1 MB skip rich conversion and fall back to plain text.
- Capture-side, stored pasteboard HTML is capped at the sync layer's own inline payload bound (`CKSchema.inlineLimit`); oversized HTML is dropped and conversions fall back to RTF/plain text as before.

## Screenshots


**Before:**
![00-baseline screenshots bar.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/00-baseline/screenshots/bar.png)

**After:**
![12-paste-as-formats screenshots after.png](https://raw.githubusercontent.com/alvst/pesty/pr-assets/v2/12-paste-as-formats/screenshots/after.png)

## Notes for review

- **`htmlData` is not carried by iCloud sync**, so the same clip can produce different Markdown on a synced Mac — the one that captured it converts from HTML, the other falls back to RTF or plain text. It degrades gracefully rather than failing, and extending the sync schema for it felt like the wrong thing to bundle into this PR. Stating it rather than letting it be discovered.
- **Markdown scope is deliberately narrow**: text plus bold, italic, underline, and links. Headings, lists, and strikethrough are not emitted — Clean Formatting keeps strikethrough, Markdown doesn't. The converters only round-trip what they can represent faithfully; guessing at heading levels from font sizes produces confidently wrong output.
- The strip-before-convert step means "Paste as Markdown" never issues a network request at paste time — a tracking pixel in a captured mail or web clip would otherwise have been fetched synchronously on the main thread.
- Concealed clips bail before HTML is ever read, and `htmlData` inherits the store's 0600 permissions.
- No dependencies; merges in any order.

---

**This feature should be bundled into v2.**

Part of #80.
